### PR TITLE
Update README to fix image in example docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ services:
     - POSTGRES_USER=postgres
     - POSTGRES_PASSWORD=super-secure-password
  web:
-  image: eyedp-now
+  image: centaurisolutions/eyedp
   volumes:
     - ./log:/eyedp/log
   ports:
@@ -145,6 +145,9 @@ server {
     keepalive_timeout 10;
 }
 ```
+
+To use the above configuration with the caching bits, you'll need to ensure
+that the cache directory exists: `mkdir -p /var/cache/nginx/eyedp`.
 
 ## Identity Provider
 


### PR DESCRIPTION
additionally, this change notes that creation of the
nginx cache directory is required