### PR TITLE
Resolve "Error 500 when trying to destroy OAuth application entry in admin area"

### DIFF
--- a/db/migrate/20200601141938_update_oauth_open_id_requests_foreign_keys.rb
+++ b/db/migrate/20200601141938_update_oauth_open_id_requests_foreign_keys.rb
@@ -1,0 +1,40 @@
+class UpdateOauthOpenIdRequestsForeignKeys < ActiveRecord::Migration[6.0]
+  # disable_ddl_transaction!
+
+  def change
+    # remove_foreign_key :users, column: :admin_id
+    # add_foreign_key :users, :admins, column: :admin_id, on_delete: :nullify
+    remove_foreign_key(
+      :oauth_openid_requests,
+      :oauth_access_grants,
+      column: :access_grant_id)
+
+    add_foreign_key(
+      :oauth_openid_requests,
+      :oauth_access_grants,
+      column: :access_grant_id,
+      on_delete: :cascade)
+  end
+
+  # def up
+  #       # remove_foreign_key(:oauth_openid_requests, name: existing_foreign_key_name)
+
+  # end
+
+  # def down
+  #   remove_foreign_key(
+  #     :oauth_openid_requests,
+  #     :oauth_access_grants,
+  #     column: :access_grant_id,
+  #     on_delete: :cascade)
+
+  #   add_foreign_key(
+  #     :oauth_openid_requests,
+  #     :oauth_access_grants,
+  #     column: :access_grant_id
+  #   )
+  #   # remove_foreign_key(:oauth_openid_requests, name: new_foreign_key_name)
+  # end
+
+  # private
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_09_181601) do
+ActiveRecord::Schema.define(version: 2020_06_01_141938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -179,7 +179,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_181601) do
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
-  add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id"
+  add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "user_groups", "groups"
   add_foreign_key "user_groups", "users"
 end


### PR DESCRIPTION
A missing on_delete: :cascade constraint on the oauth_openid_requests table is currently causing trouble when deleting applications from the Admin area.

This is because:

1. On deleting an application, all of its related access_grants records are deleted by delete_all callback (https://github.com/doorkeeper-gem/doorkeeper/blob/v4.3.1/lib/doorkeeper/orm/active_record/application.rb#L8)
1. Since a delete_all callback is executed, the dependent: :delete callback on it's corresponding oauth_openid_request record on access_grants do not run. (https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/v1.5.0/lib/doorkeeper/openid_connect/orm/active_record/access_grant.rb#L9)
1. Since this callback does not run and access_grant records are forced to be deleted, the existing foreign_key constraint on
oauth_openid_request gives an error