### PR TITLE
Allow a user to be expired

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -40,7 +40,7 @@ class Admin::UsersController < AdminController
     )
     # binding.pry
     p[:groups] = Group.where(id: p[:groups].reject(&:empty?)) if p[:groups]
-    p.delete(:password) if p[:password].empty?
+    p.delete(:password) if p[:password] && p[:password].empty?
     p
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -25,7 +25,7 @@ class Admin::UsersController < AdminController
   end
 
   def whitelist_attributes
-    %w[email name username groups]
+    %w[email name username groups expires_at]
   end
 
   def model
@@ -34,7 +34,10 @@ class Admin::UsersController < AdminController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def model_params
-    p = params.require(:user).permit(:email, :username, :password, :email, :name, groups: [])
+    p = params.require(:user).permit(
+      :email, :username, :password, :email, :name, :expires_at,
+      groups: []
+    )
     # binding.pry
     p[:groups] = Group.where(id: p[:groups].reject(&:empty?)) if p[:groups]
     p.delete(:password) if p[:password].empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,18 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     }
   end
 
+  def active_for_authentication?
+    super && !expired?
+  end
+
+  def expired?
+    expires_at.present? && expires_at < Time.current
+  end
+
+  def inactive_message
+    expired? ? :user_expired : super
+  end
+
   def admin?
     @admin ||= groups.include?(Group.find_by(name: 'administrators'))
   end

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,5 +1,5 @@
 <h2><%= @model.class.name %> <%= @model %></h2>
-
+<%= render partial: 'sub_heading' %>
 <div class="row">
   <dl>
     <%- model_attributes.each do |attribute| %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -46,6 +46,18 @@
   <div class="form-group">
     <div class="row">
       <div class="col-sm-2">
+        <%= form.label :expires_at %>
+      </div>
+      <div class="col-sm-10">
+          <%= form.text_field :expires_at, class: 'form-control', placeholder: 'YYYY-MM-DD HH:MM:SS TZ' %>
+          <a href='#' onclick="expire_now()">Now</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-2">
         <%= form.label :password %>
       </div>
       <div class="col-sm-10">
@@ -77,5 +89,9 @@
 function generate() {
   password=Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
   $('#user_password').val(password);
+}
+
+function expire_now() {
+  $('#user_expires_at').val("<%= Time.now.utc %>");
 }
 </script>

--- a/app/views/admin/users/_sub_heading.html.erb
+++ b/app/views/admin/users/_sub_heading.html.erb
@@ -1,0 +1,5 @@
+<%- if @model.expired? %>
+  <div class="alert alert-warning" role="alert">
+      <%= content_tag :div, "This user is expired" %>
+    </div>
+<%- end %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,8 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      user:
+        user_expired: "Your account is expired."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/db/migrate/20200924120339_add_expires_at_to_users.rb
+++ b/db/migrate/20200924120339_add_expires_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_18_103309) do
+ActiveRecord::Schema.define(version: 2020_09_24_120339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -178,6 +178,7 @@ ActiveRecord::Schema.define(version: 2020_09_18_103309) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.datetime "expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController, type: :controller do
+  let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+  let(:group) { Group.create!(name: 'administrators') }
+  let(:admin) do
+    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test1234')
+    user.groups << group
+    user
+  end
+
+  describe 'User' do
+    context 'signed in admin' do
+      before do
+        sign_in(admin)
+      end
+
+      it 'Shows the index page' do
+        get :index
+        expect(response.status).to eq(200)
+      end
+
+      context 'Edit' do
+        it 'can expire a user' do
+          expect(user.expired?).to be false
+          post(:update, params: { id: user.id, user: { expires_at: 10.minutes.ago } })
+          expect(response.status).to eq(302)
+          user.reload
+          expect(user.expired?).to be true
+        end
+      end
+    end
+
+    context 'signed in user' do
+      before do
+        sign_in(user)
+      end
+      it 'returns 404 code' do
+        expect { get :index }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context 'signed out user' do
+      it 'returns 404 code' do
+        expect { get :index }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -28,5 +28,14 @@ RSpec.describe ProfileController, type: :controller do
       get :show
       expect(response.body).to include('this is a fairly high entropy test string')
     end
+
+    it 'blocks expired users' do
+      user.update!(expires_at: 10.minutes.ago)
+
+      get :show
+      expect(flash[:alert])
+        .to match(/account is expired/)
+      expect(response.body).to include('redirected')
+    end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe SessionsController do
 
           expect(subject.current_user).to eq user
         end
+
+        it 'does not authenticate an expired user' do
+          user.update!(expires_at: 10.minutes.ago)
+
+          post(:create, params: { user: user_params })
+          expect(flash[:alert])
+            .to match(/account is expired/)
+        end
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe User, type: :model do
     expect(user.login).to eq 'example2'
   end
 
+  it 'can be expired' do
+    user.update!(expires_at: 10.minutes.ago)
+    expect(user.expired?).to be true
+  end
+
   it_behaves_like 'two_factor_authenticatable'
   it_behaves_like 'two_factor_backupable'
 end


### PR DESCRIPTION
When a user is expired, new logins must not work, and existing
sessions must also expire. This is enforced in this change by
overriding the method `active_for_authentication?` in the User
model.

Closes #78