### PR TITLE
Add support for a User to expire after inactivity

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -8,13 +8,14 @@ class Admin::SettingsController < AdminController
 
   # PATCH/PUT /admin/settings/1
   # PATCH/PUT /admin/settings/1.json
-  def update
+  def update # rubocop:disable Metrics/MethodLength
     opts = setting_params
     opts[:registration_enabled] = if opts[:registration_enabled].nil?
                                     false
                                   else
                                     true
                                   end
+    opts[:expire_after] = opts[:expire_after].to_i.days if opts[:expire_after]
     opts.each do |setting, value|
       Setting.send("#{setting}=", value)
     end
@@ -36,7 +37,8 @@ class Admin::SettingsController < AdminController
       :oidc_signing_key,
       :registration_enabled,
       :logo, :logo_height, :logo_width,
-      :home_template, :registered_home_template
+      :home_template, :registered_home_template,
+      :expire_after
     )
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -25,7 +25,7 @@ class Admin::UsersController < AdminController
   end
 
   def whitelist_attributes
-    %w[email name username groups expires_at]
+    %w[email name username groups expires_at last_activity_at]
   end
 
   def model
@@ -36,7 +36,7 @@ class Admin::UsersController < AdminController
   def model_params
     p = params.require(:user).permit(
       :email, :username, :password, :email, :name, :expires_at,
-      groups: []
+      :last_activity_at, groups: []
     )
     # binding.pry
     p[:groups] = Group.where(id: p[:groups].reject(&:empty?)) if p[:groups]

--- a/app/models/concerns/devise/models/expirable.rb
+++ b/app/models/concerns/devise/models/expirable.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'devise/warden/hooks/expirable'
+
+module Devise
+  module Models
+    # Deactivate the account after a configurable amount of time.  To be able to
+    # tell, it tracks activity about your account with the following columns:
+    #
+    # * last_activity_at - A timestamp updated when the user requests a page (only signed in)
+    #
+    # == Options
+    # +:expire_after+ - Time interval to expire accounts after
+    #
+    # == Additions
+    # Best used with two cron jobs. One for expiring accounts after inactivity,
+    # and another, that deletes accounts, which have expired for a given amount
+    # of time (for example 90 days).
+    #
+    module Expirable
+      extend ActiveSupport::Concern
+
+      # Updates +last_activity_at+, called from a Warden::Manager.after_set_user hook.
+      def update_last_activity!
+        update_column(:last_activity_at, Time.now.utc) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      # Tells if the account has expired
+      #
+      # @return [bool]
+      def expired?
+        # expires_at set (manually, via cron, etc.)
+        return expires_at < Time.now.utc unless expires_at.nil?
+        # if it is not set, check the last activity against configured expire_after time range
+        return false if Setting.expire_after.nil?
+        return last_activity_at < Setting.expire_after.ago unless last_activity_at.nil?
+
+        # if last_activity_at is nil as well, the user has to be 'fresh' and is therefore not expired
+        false
+      end
+
+      # Expire an account. This is for cron jobs and manually expiring of accounts.
+      #
+      # @example
+      #   User.expire!
+      #   User.expire! 1.week.from_now
+      # @note +expires_at+ can be in the future as well
+      def expire!(at = Time.now.utc)
+        self.expires_at = at
+        save(validate: false)
+      end
+
+      # Overwrites active_for_authentication? from Devise::Models::Activatable
+      # for verifying whether a user is active to sign in or not. If the account
+      # is expired, it should never be allowed.
+      #
+      # @return [bool]
+      def active_for_authentication?
+        super && !expired?
+      end
+
+      # The message sym, if {#active_for_authentication?} returns +false+. E.g. needed
+      # for i18n.
+      def inactive_message
+        !expired? ? super : :expired
+      end
+
+      module ClassMethods
+        ::Devise::Models.config(self, :expire_after, :delete_expired_after)
+
+        # Sample method for daily cron to mark expired entries.
+        #
+        # @example You can overide this in your +resource+ model
+        #   def self.mark_expired
+        #     puts 'overwritten mark_expired'
+        #   end
+        def mark_expired
+          all.find_each do |u|
+            u.expire! if u.expired? && u.expires_at.nil?
+          end
+          nil
+        end
+
+        # Scope method to collect all expired users since +time+ ago
+        def expired_for(time = delete_expired_after)
+          where('expires_at < ?', time.seconds.ago)
+        end
+
+        # Sample method for daily cron to delete all expired entries after a
+        # given amount of +time+.
+        #
+        # In your overwritten method you can "blank out" the object instead of
+        # deleting it.
+        #
+        # *Word of warning*: You have to handle the dependent method
+        # on the +resource+ relations (+:destroy+ or +:nullify+) and catch this
+        # behavior (see  http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#label-Deleting+from+associations).
+        #
+        # @example
+        #   Resource.delete_all_expired_for 90.days
+        # @example You can overide this in your +resource+ model
+        #   def self.delete_all_expired_for(time = 90.days)
+        #     puts 'overwritten delete call'
+        #   end
+        # @example Overwritten version to blank out the object.
+        #   def self.delete_all_expired_for(time = 90.days)
+        #     expired_for(time).each do |u|
+        #       u.update_attributes first_name: nil, last_name: nil
+        #     end
+        #   end
+        def delete_all_expired_for(time)
+          expired_for(time).delete_all
+        end
+
+        # Version of {#delete_all_expired_for} without arguments (uses
+        # configured +delete_expired_after+ default value).
+        # @see #delete_all_expired_for
+        def delete_all_expired
+          delete_all_expired_for(delete_expired_after)
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/devise/warden/hooks/expirable.rb
+++ b/app/models/concerns/devise/warden/hooks/expirable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Updates the last_activity_at fields from the record. Only when the user is active
+# for authentication and authenticated.
+# An expiry of the account is only checked on sign in OR on manually setting the
+# expired_at to the past (see Devise::Models::Expirable for this)
+Warden::Manager.after_set_user do |record, warden, options|
+  if record&.respond_to?(:active_for_authentication?) && record&.active_for_authentication? &&
+     warden.authenticated?(options[:scope]) && record.respond_to?(:update_last_activity!)
+    record.update_last_activity!
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -102,6 +102,12 @@ class Setting < ApplicationRecord
         return value
       when :integer
         return value.to_i
+      when :time
+        if value.is_a?(String)
+          return ActiveSupport::Duration::parse(value)
+        else
+          return value.iso8601
+        end
       else
         value
       end
@@ -141,4 +147,6 @@ class Setting < ApplicationRecord
 
   field :home_template, default: '', type: :string
   field :registered_home_template, default: '', type: :string
+
+  field :expire_after, type: :time
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,8 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   devise :registerable, :recoverable, :rememberable, :validatable,
          :fido_usf_registerable
 
+  devise :expirable
+
   has_many :user_groups, dependent: :destroy
   has_many :groups, through: :user_groups
   has_many :group_permissions, through: :groups
@@ -111,14 +113,6 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
         # name_id_format: Saml::XML::Namespaces::Formats::NameId::NAME
       }
     }
-  end
-
-  def active_for_authentication?
-    super && !expired?
-  end
-
-  def expired?
-    expires_at.present? && expires_at < Time.current
   end
 
   def inactive_message

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -10,6 +10,11 @@
       <td>Enable User Registration</td>
       <td><input type="checkbox" name="setting[registration_enabled]" class="form-control" <% if Setting.registration_enabled %>checked <% end %> value="" /></td>
     </tr>
+    <tr>
+      <td>Expire User after inactivity</td>
+      <td><input type="text" name="setting[expire_after]" class="form-control" value="<%= Setting.expire_after.parts[:days] %>" />
+        <p class="small">Number of days after which a user should be deactivated. Empty disables this feature.</p></td>
+    </tr>
     <!-- Logo settings -->
   </table>
   <h3>Branding</h3>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -58,6 +58,18 @@
   <div class="form-group">
     <div class="row">
       <div class="col-sm-2">
+        <%= form.label :last_activity_at %>
+      </div>
+      <div class="col-sm-10">
+          <%= form.text_field :last_activity_at, class: 'form-control' %>
+          <a href='#' onclick="clear_activity()">Reset</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-2">
         <%= form.label :password %>
       </div>
       <div class="col-sm-10">
@@ -93,5 +105,9 @@ function generate() {
 
 function expire_now() {
   $('#user_expires_at').val("<%= Time.now.utc %>");
+}
+
+function clear_activity() {
+  $('#user_last_activity_at').val("");
 }
 </script>

--- a/db/migrate/20200929072357_add_last_activity_at_to_users.rb
+++ b/db/migrate/20200929072357_add_last_activity_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastActivityAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :last_activity_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_120339) do
+ActiveRecord::Schema.define(version: 2020_09_29_072357) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_120339) do
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
     t.datetime "expires_at"
+    t.datetime "last_activity_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/basic_auth_controller_spec.rb
+++ b/spec/controllers/basic_auth_controller_spec.rb
@@ -17,12 +17,16 @@ RSpec.describe BasicAuthController, type: :controller do
     let(:group) { Group.create!(name: 'my_group', permissions: [permission]) }
 
     it 'allows authenticated role with group' do
+      start = user.last_activity_at
       @request.env['devise.mapping'] = Devise.mappings[:user]
       user.groups << group
       sign_in user
       get :create, params: { permission_name: 'use.test_app' }
       expect(response.status).to eq(200)
+      user.reload
+      expect(user.last_activity_at).not_to eq(start)
     end
+
     it 'forbids authenticated role without group' do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       sign_in user

--- a/spec/controllers/oauth_applications_controller_spec.rb
+++ b/spec/controllers/oauth_applications_controller_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe OauthApplicationsController, type: :controller do
     end
 
     describe 'Existing Login' do
-      it 'records the login'  do
+      it 'updates user activity' do
+        start = user.last_activity_at
+        get :create, params: params
+        user.reload
+        expect(user.last_activity_at).not_to eq(start)
+      end
+
+      it 'records the login' do
         # @request.env['devise.mapping'] = Devise.mappings[:user]
         get :create, params: params
         expect(response.status).to eq(302)
@@ -29,6 +36,13 @@ RSpec.describe OauthApplicationsController, type: :controller do
     end
 
     describe 'New login' do
+      it 'updates user activity' do
+        start = user.last_activity_at
+        get :create, params: params
+        user.reload
+        expect(user.last_activity_at).not_to eq(start)
+      end
+
       it 'records the login' do
         # @request.env['devise.mapping'] = Devise.mappings[:user]
         get :create, params: params

--- a/spec/controllers/profile/account_activity_spec.rb
+++ b/spec/controllers/profile/account_activity_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Profile::AccountActivityController, type: :controller do
+RSpec.describe Profile::AccountActivityController, type: :controller do # rubocop:disable Metrics/BlockLength
   let(:user) { User.create!(username: 'example', email: 'test@localhost', password: 'test1234') }
   let(:app) do
     Application.create!(
@@ -28,6 +28,13 @@ RSpec.describe Profile::AccountActivityController, type: :controller do
       get :index
       expect(response.body).to include('Existing Login')
       expect(response.body).to include(app.name)
+    end
+
+    it 'updates user activity' do
+      start = user.last_activity_at
+      get :index
+      user.reload
+      expect(user.last_activity_at).not_to eq(start)
     end
   end
 end

--- a/spec/controllers/profile/authentication_devices_spec.rb
+++ b/spec/controllers/profile/authentication_devices_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Profile::AuthenticationDevicesController, type: :controller do
+RSpec.describe Profile::AuthenticationDevicesController, type: :controller do # rubocop:disable Metrics/BlockLength
   let(:user) do
     User.create!(
       username: 'example',
@@ -23,6 +23,13 @@ RSpec.describe Profile::AuthenticationDevicesController, type: :controller do
       user.save
       get :index
       expect(response.body).to include('TOTP')
+    end
+
+    it 'updates user activity' do
+      start = user.last_activity_at
+      get :index
+      user.reload
+      expect(user.last_activity_at).not_to eq(start)
     end
   end
 end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -37,5 +37,12 @@ RSpec.describe ProfileController, type: :controller do
         .to match(/account is expired/)
       expect(response.body).to include('redirected')
     end
+
+    it 'updates user activity' do
+      start = user.last_activity_at
+      get :show
+      user.reload
+      expect(user.last_activity_at).not_to eq(start)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,6 +68,39 @@ RSpec.describe User, type: :model do
     expect(user.expired?).to be true
   end
 
+  context 'Expirable' do
+    context 'expire_after 30 days' do
+      before do
+        Setting.expire_after = 30.days
+      end
+      after do
+        Setting.expire_after = nil
+      end
+      it 'expires a user' do
+        expect(user.expired?).to be false
+        user.last_activity_at = 31.days.ago
+        expect(user.expired?).to be true
+      end
+
+      it 'allows unexpired users' do
+        expect(user.expired?).to be false
+        user.last_activity_at = 10.days.ago
+        expect(user.expired?).to be false
+      end
+    end
+
+    context 'expire_after nil' do
+      before do
+        Setting.expire_after = nil
+      end
+      it 'expires a user' do
+        expect(user.expired?).to be false
+        user.last_activity_at = 2.years.ago
+        expect(user.expired?).to be false
+      end
+    end
+  end
+
   it_behaves_like 'two_factor_authenticatable'
   it_behaves_like 'two_factor_backupable'
 end


### PR DESCRIPTION
When configured, a User will be expired after a period
of inactivity, with the ability to re re-enabled by an
admin.

Closes #101