### PR TITLE
An admin can not set a user password

### DIFF
--- a/.env
+++ b/.env
@@ -25,3 +25,4 @@ RAILS_MAX_THREADS=5
 TOTP_ENCRYPTION_KEY=something-really-awesome-that's-at-least-32-bytes
 
 SMTP_PORT=1025
+EMAIL_DOMAIN=localhost

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,12 +2,25 @@
 
 class UserMailer < ApplicationMailer
   default from: Setting.welcome_from_email
-  layout false
 
   def group_welcome_email(user, group)
     @user = user
     @group = group
     mail(to: @user.email,
-         subject: "Welcome to #{@group.name}")
+         subject: I18n.t("Welcome to #{@group.name}"))
+  end
+
+  def force_reset_password_email(user, token)
+    @user = user
+    @token = token
+    mail(to: @user.email,
+         subject: I18n.t('Password Changed'))
+  end
+
+  def admin_welcome_email(user, token)
+    @user = user
+    @token = token
+    mail(to: @user.email,
+         subject: I18n.t('Your account has been created'))
   end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,3 +1,17 @@
+<%- if not new_model %>
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-2">
+        <Label>Password</Label>
+      </div>
+      <div class="col-sm-10">
+        <%= form_with(url: 'reset_password', local: true, class: 'form') do |_form| %>
+          <button class="btn btn-warning">Reset</a>
+        <%- end %>
+      </div>
+    </div>
+  </div>
+<%- end %>
 <%= form_with(model: [:admin, model], local: true, class: 'form') do |form| %>
   <% if model.errors.any? %>
     <div id="error_explanation">
@@ -67,17 +81,6 @@
     </div>
   </div>
 
-  <div class="form-group">
-    <div class="row">
-      <div class="col-sm-2">
-        <%= form.label :password %>
-      </div>
-      <div class="col-sm-10">
-          <%= form.text_field :password, class: 'form-control' %> <a href='#' onclick="generate()">Generate</a>
-      </div>
-    </div>
-  </div>
-
     <%- form_relations.each do |relation_name, info| %>
 
     <div class="form-group">
@@ -98,10 +101,6 @@
 <% end %>
 
 <script>
-function generate() {
-  password=Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
-  $('#user_password').val(password);
-}
 
 function expire_now() {
   $('#user_expires_at').val("<%= Time.now.utc %>");

--- a/app/views/user_mailer/admin_welcome_email.html.erb
+++ b/app/views/user_mailer/admin_welcome_email.html.erb
@@ -1,0 +1,6 @@
+<p>Hello <%= @user.email %>!</p>
+
+<p>An administrator of <%= link_to root_url, root_url %> has created an account for you. To login, you will first need to set your passsword which can be done through the link below.</p>
+
+<p><%= link_to 'Set my password', edit_password_url(@user, reset_password_token: @token) %></p>
+

--- a/app/views/user_mailer/force_reset_password_email.html.erb
+++ b/app/views/user_mailer/force_reset_password_email.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @user.email %>!</p>
+
+<p>An administrator has reset your password so you must now update it. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@user, reset_password_token: @token) %></p>
+
+<p>You will be unable to login until your password is updated.</p>

--- a/app/views/user_mailer/group_welcome_email.html.erb
+++ b/app/views/user_mailer/group_welcome_email.html.erb
@@ -1,9 +1,1 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  </head>
-  <body>
-    <%= @group.rendered_welcome_email(@user).html_safe %>
-  </body>
-</html>
+<%= @group.rendered_welcome_email(@user).html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
     resources :groups do
       get :email, to: 'groups#email'
     end
-    resources :users
+    resources :users do
+      post :reset_password, to: 'users#reset_password'
+    end
     resources :permissions
     resources :applications
     resources :saml_service_providers

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -129,6 +129,13 @@ RSpec.describe User, type: :model do
     end
   end
 
+  it 'sends a password reset email with a forced reset' do
+    expect do
+      perform_enqueued_jobs do
+        user.force_password_reset!
+      end
+    end.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
   it_behaves_like 'two_factor_authenticatable'
   it_behaves_like 'two_factor_backupable'
 end


### PR DESCRIPTION
Instead of allowing an admin to set the password for a user, the
admin now has a button that they can use to trigger a password
reset for a user, which also sends a notification email to the
user with a reset link.

Additionally, this change introduces a new welcome email that
will be sent when an admin creates a new user and also includes
a password reset link for the new user.

Closes #110