### PR TITLE
Only update a user password before validations when nil

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ProfileController < ApplicationController
+  before_action :authenticate_user!
   def show
     @template = Liquid::Template.parse(Setting.registered_home_template)
     @logins = current_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  before_action :authenticate_user!
   def new_2fa
     current_user.otp_secret = User.generate_otp_secret(32) unless current_user.two_factor_otp_enabled?
     current_user.save!
-
     @qr_code = build_qr_code
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -191,6 +191,6 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   private
 
   def ensure_password
-    self.password ||= SecureRandom.hex(32)
+    self.password = SecureRandom.hex(32) if encrypted_password.blank?
   end
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Admin::UsersController, type: :controller do
           expect do
             perform_enqueued_jobs do
               post(:create, params: { user: { email: 'test@example.com', username: 'test' } })
+              expect(response.status).to eq(302)
             end
           end.to change { ActionMailer::Base.deliveries.count }.by(1)
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe User, type: :model do
     expect(user.expired?).to be true
   end
 
+  it 'only changes password when encrypted_password is nil' do
+    user.password = nil
+    expect(user.valid_password?('test1234')).to be true
+    user.save
+    expect(user.valid_password?('test1234')).to be true
+    old_encrypted = user.encrypted_password
+    user.encrypted_password = nil
+    user.save
+    expect(user.encrypted_password).not_to eq(old_encrypted)
+  end
+
   context 'Expirable' do
     context 'expire_after 30 days' do
       before do


### PR DESCRIPTION
If we unconditionally run the check, the password will always
be randomly updated when the user saves, as `password` will be
nil _except_ for the case where a user is updating their password.

This change requires that encrypted_password be nil as well before
updating the empty password.

There is a minor change expanding the user of `authenticate_user!`
to reduce potential exceptions being thrown via users poking around
where they should not.

Closes-Bug: #122