### PR TITLE
Add a new admin_welcome_email_template to Settings

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -52,7 +52,7 @@ class Admin::SettingsController < AdminController
       :logo, :logo_height, :logo_width,
       :home_template, :registered_home_template,
       :expire_after, :welcome_from_email,
-      :admin_reset_email_template
+      :admin_reset_email_template, :admin_welcome_email_template
     )
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -23,6 +23,9 @@ class UserMailer < ApplicationMailer
   def admin_welcome_email(user, token)
     @user = user
     @token = token
+    if Setting.admin_welcome_email_template.present?
+      @template = Liquid::Template.parse(Setting.admin_welcome_email_template)
+    end
     mail(to: @user.email,
          subject: 'Your account has been created')
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -160,4 +160,5 @@ class Setting < ApplicationRecord
   field :permemant_username, type: :boolean, default: true
 
   field :admin_reset_email_template, default: '', type: :string
+  field :admin_welcome_email_template, default: '', type: :string
 end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -46,6 +46,12 @@
       </td>
     </tr>
     <tr>
+      <td>Admin created user welcome template</td>
+      <td>
+        <textarea name="setting[admin_welcome_email_template]" class="form-control" ><%= Setting.admin_welcome_email_template %></textarea>
+      </td>
+    </tr>
+    <tr>
       <td>Logo</td>
       <td>
         <input type="text" name="setting[logo]" class="form-control" value="<%= Setting.logo %>" />

--- a/app/views/user_mailer/admin_welcome_email.html.erb
+++ b/app/views/user_mailer/admin_welcome_email.html.erb
@@ -1,6 +1,11 @@
+<%- if @template %>
+<%- vars = template_variables(@user) %>
+<%- vars['reset_link'] = edit_password_url(@user, reset_password_token: @token) %>
+<%= @template.render(vars).html_safe %>
+<%- else %>
 <p>Hello <%= @user.email %>!</p>
 
 <p>An administrator of <%= link_to root_url, root_url %> has created an account for you. To login, you will first need to set your passsword which can be done through the link below.</p>
 
 <p><%= link_to 'Set my password', edit_password_url(@user, reset_password_token: @token) %></p>
-
+<%- end %>

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe Admin::SettingsController, type: :controller do
           post(:update, params: { setting: { admin_reset_email_template: 'Password was reset!' } })
           expect(Setting.admin_reset_email_template).to eq 'Password was reset!'
         end
+
+        it 'can set user creation template' do
+          post(:update, params: { setting: { admin_welcome_email_template: 'welcome to eyedp!' } })
+          expect(Setting.admin_welcome_email_template).to eq 'welcome to eyedp!'
+        end
       end
     end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserMailer, type: :mailer do # rubocop:disable Metrics/BlockLength
+  context 'group_welcome_email' do
+    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+    let(:group) { Group.create!(name: 'administrators') }
+
+    let(:mail) { UserMailer.group_welcome_email(user, group) }
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Welcome to administrators')
+      expect(mail.to).to eq(['user@localhost'])
+      expect(mail.from).to eq(['noreply@example.com'])
+    end
+
+    it 'is customized with welcome_email' do
+      group.welcome_email = 'Hey there'
+      group.save
+      expect(mail.body.encoded).to match('Hey there')
+    end
+  end
+
+  context 'force_reset_password_email' do
+    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+    let(:mail) { UserMailer.force_reset_password_email(user, 'test token') }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Password Changed')
+      expect(mail.to).to eq(['user@localhost'])
+      expect(mail.from).to eq(['noreply@example.com'])
+    end
+
+    it 'supports a default' do
+      expect(mail.body.encoded).to match('reset your password so you must now update it')
+    end
+
+    it 'can be customized' do
+      Setting.admin_reset_email_template = 'this is a test!'
+      expect(mail.body.encoded).to match('this is a test')
+    end
+  end
+
+  context 'admin_welcome_email' do
+    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+    let(:mail) { UserMailer.admin_welcome_email(user, 'test token') }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Your account has been created')
+      expect(mail.to).to eq(['user@localhost'])
+      expect(mail.from).to eq(['noreply@example.com'])
+    end
+
+    it 'supports a default' do
+      expect(mail.body.encoded).to match('has created an account for you')
+    end
+
+    it 'can be customized' do
+      Setting.admin_welcome_email_template = 'this is a test!'
+      expect(mail.body.encoded).to match('this is a test')
+    end
+  end
+end


### PR DESCRIPTION
This new template is added along with unit tests for the custom
email templates added with the force_password_reset_template
that was added in an urgent fashion.

Closes #120