### PR TITLE
Update user experience with admin Reset Password

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,10 +10,11 @@ class Admin::UsersController < AdminController
     @model = User.find(params[:user_id])
     respond_to do |format|
       if @model.force_password_reset!
-        format.html { redirect_to [:admin, @model], notice: "#{@model.class.name} was successfully updated." }
+        format.html { redirect_to [:edit, :admin, @model], notice: 'Password reset was processed successfully' }
         format.json { render :show, status: :ok, location: [:admin, @model] }
       else
-        format.html { render :edit }
+        format.html { redirect_to [:admin, @model, :edit], notice: 'There was a problem processing the password reset' }
+
         format.json { render json: @model.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,8 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     token = set_reset_password_token
     return false unless UserMailer.force_reset_password_email(self, token).deliver_later
+
+    true
   end
 
   def send_admin_welcome_email

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -5,9 +5,7 @@
         <Label>Password</Label>
       </div>
       <div class="col-sm-10">
-        <%= form_with(url: 'reset_password', local: true, class: 'form') do |_form| %>
-          <button class="btn btn-warning">Reset</a>
-        <%- end %>
+        <%= link_to 'Reset Password', [:admin, model, :reset_password], method: :post, data: { confirm: 'Are you sure? Clicking reset multiple times will send multiple reset emails to the user.'}, class: "btn btn-warning"  %>
       </div>
     </div>
   </div>

--- a/app/views/admin/users/_sub_heading.html.erb
+++ b/app/views/admin/users/_sub_heading.html.erb
@@ -3,3 +3,4 @@
       <%= content_tag :div, "This user is expired" %>
     </div>
 <%- end %>
+<%= link_to 'Reset Password', [:admin, @model, :reset_password], method: :post, data: { confirm: 'Are you sure? Clicking reset multiple times will send multiple reset emails to the user.'}, class: "btn btn-warning"  %>

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Admin::UsersController, type: :controller do
         it 'can reset a user passowrd' do
           expect(user.valid_password?('test1234')).to be true
           post(:reset_password, params: { user_id: user.id })
-          expect(response.status).to eq(200)
+          expect(response.status).to eq(302)
           user.reload
           expect(user.valid_password?('test1234')).to be false
         end


### PR DESCRIPTION
This change updates the reset password for an admin to include
a confirmation dialog before submitting the reset request,
and additionally adds a reset password button to the User
show page.

There is a bit of additional tidying performed in the
User#force_reset_password! method to ensure that we return
True/False, rather than nil/False, making error propegation
to the admin better.

Closes #141