### PR TITLE
Improve the admin/index pages to be more functional

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -22,16 +22,20 @@ class Admin::UsersController < AdminController
 
   private
 
-  # def model_attributes
-  #   model.attribute_names - ['id', 'created_at', 'updated_at', 'encrypted_password']
-  # end
+  def can_destroy?
+    false
+  end
 
   def includes
     [:groups]
   end
 
-  def whitelist_attributes
+  def show_whitelist_attributes
     %w[email name username groups expires_at last_activity_at]
+  end
+
+  def whitelist_attributes
+    %w[email username name groups expired?]
   end
 
   def model

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,7 @@ class UsersController < ApplicationController
   def disable_2fa
     current_user.disable_two_factor! params[:otp_only]
 
-    redirect_to edit_user_registration_path,
+    redirect_to authenticated_root_path,
                 status: :found,
                 notice: s_('Two-factor authentication has been disabled successfully!')
   end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -4,6 +4,7 @@
 <table class="table table-striped">
   <thead>
     <tr>
+      <th></th>
       <%- model_attributes.each do |attr_name| %>
         <th>
           <%= attr_name %>
@@ -27,26 +28,27 @@
           <%- end %>
         </th>
       <%- end %>
-      <th colspan="3"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @models.each do |model| %>
       <tr>
+        <td><nobr><%= link_to fa_icon('eye'), [:admin, model] %>
+        <%= link_to fa_icon('pencil'), ['edit', :admin, model] %>
+        <%- if can_destroy? %>
+          <%= link_to fa_icon('trash-o'), [:admin, model], method: :delete, data: { confirm: 'Are you sure?' } %>
+        <%- end %>
+          </nobr></td>
         <%- model_attributes.each do |attr_name| %>
           <td>
             <%- data = model.send(attr_name) %>
             <%- if data.is_a? ActiveRecord::Associations::CollectionProxy %>
-              <%= data.join ", " %>
-            <%- else %>
-              <%= data %>
+              <%- data =  data.join ", " %>
             <%- end %>
+            <%= data %>
           </td>
         <%- end %>
-        <td><%= link_to 'Show', [:admin, model] %></td>
-        <td><%= link_to 'Edit', ['edit', :admin, model] %></td>
-        <td><%= link_to 'Destroy', [:admin, model], method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/devise/fido_usf_registrations/new.html.erb
+++ b/app/views/devise/fido_usf_registrations/new.html.erb
@@ -19,7 +19,7 @@
           <%= form_with id: "form-register", url: user_fido_usf_registration_path() do |f| %>
             <%= f.hidden_field :response %>
           <% end %>
-          <%= link_to 'Cancel', edit_user_registration_path(), class: "btn btn-secondary" %>
+          <%= link_to 'Cancel', profile_authentication_devices_path(), class: "btn btn-secondary" %>
         </div>
       </div>
       <div id="error" class="d-none card border-danger">
@@ -28,7 +28,7 @@
         </div>
         <div class="card-body">
           <p id="error-text" class="card-text text-danger">None</p>
-          <%= link_to 'Cancel', edit_user_registration_path(), class: "btn btn-secondary" %>
+          <%= link_to 'Cancel', profile_authentication_devices_path(), class: "btn btn-secondary" %>
           <%= link_to 'Try again', new_user_fido_usf_registration_path(), class: "btn btn-primary" %>
         </div>
       </div>

--- a/app/views/profile/authentication_devices/index.html.erb
+++ b/app/views/profile/authentication_devices/index.html.erb
@@ -19,9 +19,12 @@
           <tr id="totp_device">
             <td>TOTP</td>
             <td><%= l(Time::at(current_user.consumed_timestep * current_user.otp.interval), format: :long) %></td>
-            <td><%= link_to _('Delete'), user_two_factor_auth_path(otp_only: true),
+            <td>
+              <%= link_to _('Delete'), user_two_factor_auth_path(otp_only: true),
               method: :delete,
-              data: { confirm: ('Are you sure? This will invalidate your registered applications and U2F devices.') } %></td>
+              data: { confirm: ('Are you sure? This will invalidate your registered applications and U2F devices.') } %> |
+              <%= link_to _('Regenerate recovery codes'), user_2fa_codes_path %>
+            </td>
           </tr>
         <%- end %>
         <% current_user.fido_usf_devices.each do |device| %>

--- a/app/views/users/_codes.html.erb
+++ b/app/views/users/_codes.html.erb
@@ -13,6 +13,6 @@
   </ul>
 </div>
 <div class="d-flex">
-  <%= link_to _('Proceed'), edit_user_registration_path, class: 'btn btn-success gl-mr-3', data: { qa_selector: 'proceed_button' } %>
+  <%= link_to _('Proceed'), profile_authentication_devices_path, class: 'btn btn-success gl-mr-3', data: { qa_selector: 'proceed_button' } %>
   <%= link_to _('Download codes'), "data:text/plain;charset=utf-8,#{CGI.escape(@codes.join("\n"))}", download: "recovery-codes.txt", class: 'btn btn-default' %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
 
   get 'users/2fa', to: 'users#new_2fa', as: 'new_user_2fa_registration'
   post 'users/2fa', to: 'users#create_2fa', as: 'user_two_factor_auth'
-  post 'users/2fa/codes', to: 'users#codes', as: 'user_2fa_codes'
+  match 'users/2fa/codes', to: 'users#codes', as: 'user_2fa_codes', via: %i[get post]
   delete '/users/2fa', to: 'users#disable_2fa'
   # SAMLv2 IdP
   get '/saml/auth' => 'saml_idp#create'


### PR DESCRIPTION
This change begins by moving the per-row actions to the left
side of the row, ensuring that the actions are always visible.
Also included is an ability to customize the show vs index page
attributes differently, which lets us include Expires and
Last Activity in the Show page for Users, while discarding
them from the index page.

It then changes the words "Show", "Edit", "destroy" into icons,
and then modifies the base admin controller to allow for disabling
model deletion, and disables deletion for Users.

Closes #150