### PR TITLE
Admin action icons should have a title attribute

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -34,10 +34,10 @@
   <tbody>
     <% @models.each do |model| %>
       <tr>
-        <td><nobr><%= link_to fa_icon('eye'), [:admin, model] %>
-        <%= link_to fa_icon('pencil'), ['edit', :admin, model] %>
+        <td><nobr><%= link_to fa_icon('eye', title: 'Show'), [:admin, model] %>
+        <%= link_to fa_icon('pencil', title: 'Edit'), ['edit', :admin, model] %>
         <%- if can_destroy? %>
-          <%= link_to fa_icon('trash-o'), [:admin, model], method: :delete, data: { confirm: 'Are you sure?' } %>
+          <%= link_to fa_icon('trash-o', title: "Delete"), [:admin, model], method: :delete, data: { confirm: 'Are you sure?' } %>
         <%- end %>
           </nobr></td>
         <%- model_attributes.each do |attr_name| %>


### PR DESCRIPTION
As can be seen in the attached image, the title attribute now shows up on mouseover :)

![title on mouseover](https://user-images.githubusercontent.com/429739/100426388-0f4c9380-3091-11eb-9590-2b63ab63283a.png)
