### PR TITLE
The settings page is divided into separate sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,22 @@ to `admin/settings` and update the values there:
 <dl>
   <dt><strong>Base</strong></dt>
   <dd>This should be updated to the root url of your installation</dd>
+</dl>
+
+Next, depending on your needs, you will need to configure SAML and OpenID Connect:
+
+To configure SAML, you should navigate to `admin/settings/saml` and update:
+
+<dl>
   <dt><strong>Certificate</strong></dt>
   <dd>This is the certificate generated in <a href='#saml'>SAML</a></dd>
   <dt><strong>Key</strong></dt>
   <dd>This is the key generated in <a href='#saml'>SAML</a></dd>
+</dl>
+
+To configure OIDC, you should navigate to `admin/settings/openid_connect` and update:
+
+<dl>
   <dt>Signing Key</dt>
   <dd>This is the key generated in <a href='#openid-connect'>OpenID Connect</a></dd>
 </dl>

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -6,6 +6,14 @@ class Admin::SettingsController < AdminController
   # GET /admin/settings.json
   def index; end
 
+  def openid_connect; end
+
+  def saml; end
+
+  def branding; end
+
+  def templates; end
+
   # PATCH/PUT /admin/settings/1
   # PATCH/PUT /admin/settings/1.json
   def update # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
@@ -41,7 +49,7 @@ class Admin::SettingsController < AdminController
     opts.each do |setting, value|
       Setting.send("#{setting}=", value)
     end
-    redirect_to admin_settings_url, notice: 'Settings were successfully updated.'
+    redirect_back fallback_location: admin_settings_url, notice: 'Settings were successfully updated.'
   end
 
   private

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -41,7 +41,7 @@
         <%- end %>
           </nobr></td>
         <%- model_attributes.each do |attr_name| %>
-          <td class="<%= attr_name.gsub(/[^\w\s]/, '') %>">
+          <td>
             <%- data = model.send(attr_name) %>
             <%- if data.is_a? ActiveRecord::Associations::CollectionProxy %>
               <%- data =  data.join ", " %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -41,7 +41,7 @@
         <%- end %>
           </nobr></td>
         <%- model_attributes.each do |attr_name| %>
-          <td>
+          <td class="<%= attr_name.gsub(/[^\w\s]/, '') %>">
             <%- data = model.send(attr_name) %>
             <%- if data.is_a? ActiveRecord::Associations::CollectionProxy %>
               <%- data =  data.join ", " %>

--- a/app/views/admin/settings/branding.html.erb
+++ b/app/views/admin/settings/branding.html.erb
@@ -1,0 +1,34 @@
+<%= form_tag({controller: "settings", action: "update"}, method: :post, class: "form") do |form| %>
+  <h1>Branding</h1>
+    <tr>
+      <td>HTML Title</td>
+      <td><input type="text" name="setting[html_title_base]" class="form-control" value="<%= Setting.html_title_base %>" /></td>
+    </tr>
+    <tr>
+      <td>Email to send welcome emails from</td>
+      <td><input type="email" name="setting[welcome_from_email]" class="form-control" value="<%= Setting.welcome_from_email %>" /></td>
+    </tr>
+    <h2>Logo</h2>
+    <!-- begin logo -->
+    <tr>
+      <td>Logo</td>
+      <td>
+        <input type="text" name="setting[logo]" class="form-control" value="<%= Setting.logo %>" />
+        <p class="small">Path to a logo file, either as a fully qualified URL or a path inside the local installation's <code>public/images</code> directory. If the path is inside the public directory, it should be just the filename inside of that directory (logo.gif, rather than public/images/logo.gif)</p>
+      </td>
+    </tr>
+    <tr>
+      <td>Logo Height</td>
+      <td>
+        <input type="text" name="setting[logo_height]" class="form-control" value="<%= Setting.logo_height %>" />
+      </td>
+    </tr>
+    <tr>
+      <td>Logo Width</td>
+      <td>
+        <input type="text" name="setting[logo_width]" class="form-control" value="<%= Setting.logo_width %>" />
+      </td>
+    </tr>
+    <!-- End logo settings -->
+  <button class="btn btn-primary">Save</button>
+<%- end %>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,18 +1,9 @@
 <h1> Settings</h1>
 <%= form_tag({controller: "settings", action: "update"}, method: :post, class: "form") do |form| %>
-  <h3>General</h3>
   <table class="table table-striped">
     <tr>
       <td>Base</td>
       <td><input type="text" name="setting[idp_base]" class="form-control" value="<%= Setting.idp_base %>" /></td>
-    </tr>
-    <tr>
-      <td>HTML Title</td>
-      <td><input type="text" name="setting[html_title_base]" class="form-control" value="<%= Setting.html_title_base %>" /></td>
-    </tr>
-    <tr>
-      <td>Email to send welcome emails from</td>
-      <td><input type="email" name="setting[welcome_from_email]" class="form-control" value="<%= Setting.welcome_from_email %>" /></td>
     </tr>
     <tr>
       <td>Enable User Registration</td>
@@ -33,90 +24,6 @@
         <p class="small">How many days to allow a password reset token to be valid.</p></td>
     </tr>
     <!-- Logo settings -->
-  </table>
-  <h3>Branding</h3>
-  <table class="table table-striped">
-    <tr>
-      <td>Home page template</td>
-      <td>
-        <textarea name="setting[home_template]" class="form-control" ><%= Setting.home_template %></textarea>
-      </td>
-    </tr>
-    <tr>
-      <td>Registered home page template</td>
-      <td>
-        <textarea name="setting[registered_home_template]" class="form-control" ><%= Setting.registered_home_template %></textarea>
-      </td>
-    </tr>
-    <tr>
-      <td>Password reset email template</td>
-      <td>
-        <textarea name="setting[admin_reset_email_template]" class="form-control" ><%= Setting.admin_reset_email_template %></textarea>
-      </td>
-    </tr>
-    <tr>
-      <td>Admin created user welcome template</td>
-      <td>
-        <textarea name="setting[admin_welcome_email_template]" class="form-control" ><%= Setting.admin_welcome_email_template %></textarea>
-      </td>
-    </tr>
-    <tr>
-      <td>Logo</td>
-      <td>
-        <input type="text" name="setting[logo]" class="form-control" value="<%= Setting.logo %>" />
-        <p class="small">Path to a logo file, either as a fully qualified URL or a path inside the local installation's <code>public/images</code> directory. If the path is inside the public directory, it should be just the filename inside of that directory (logo.gif, rather than public/images/logo.gif)</p>
-      </td>
-    </tr>
-    <tr>
-      <td>Logo Height</td>
-      <td>
-        <input type="text" name="setting[logo_height]" class="form-control" value="<%= Setting.logo_height %>" />
-      </td>
-    </tr>
-    <tr>
-      <td>Logo Width</td>
-      <td>
-        <input type="text" name="setting[logo_width]" class="form-control" value="<%= Setting.logo_width %>" />
-      </td>
-    </tr>
-    <!-- End logo settings -->
-  </table>
-
-  <h3>SAML</h3>
-  <table class="table table-striped">
-    <tbody>
-      <tr>
-        <td>Certificate</td>
-        <td>
-          <textarea name="setting[saml_certificate]" class="form-control"><%= Setting.saml_certificate %></textarea>
-          <%- if Setting.saml_certificate.present? %>
-            <%- cert = OpenSSL::X509::Certificate.new(Setting.saml_certificate) %>
-            <p class="small">Certificate Fingerprint: <%= OpenSSL::Digest::SHA1.hexdigest(cert.to_der).scan(/../).join(':').upcase %></p>
-          <%- end %>
-        </td>
-      </tr>
-
-      <tr>
-        <td>Key</td>
-        <td>
-          <textarea name="setting[saml_key]" class="form-control"><%= Setting.saml_key %></textarea>
-        </td>
-      </tr>
-
-    </tbody>
-  </table>
-
-  <h3>OpenID Connect</h3>
-  <table class="table table-striped">
-
-    <tbody>
-      <tr>
-        <td>Signing Key</td>
-        <td>
-          <textarea name="setting[oidc_signing_key]" class="form-control"><%= Setting.oidc_signing_key %></textarea>
-        </td>
-      </tr>
-    </tbody>
   </table>
   <button class="btn btn-primary">Save</button>
 <%- end %>

--- a/app/views/admin/settings/openid_connect.html.erb
+++ b/app/views/admin/settings/openid_connect.html.erb
@@ -1,0 +1,14 @@
+<%= form_tag({controller: "settings", action: "update"}, method: :post, class: "form") do |form| %>
+  <h1>OpenID Connect</h1>
+  <table class="table table-striped">
+    <tbody>
+      <tr>
+        <td>Signing Key</td>
+        <td>
+          <textarea name="setting[oidc_signing_key]" class="form-control"><%= Setting.oidc_signing_key %></textarea>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <button class="btn btn-primary">Save</button>
+<%- end %>

--- a/app/views/admin/settings/saml.html.erb
+++ b/app/views/admin/settings/saml.html.erb
@@ -1,0 +1,25 @@
+<%= form_tag({controller: "settings", action: "update"}, method: :post, class: "form") do |form| %>
+  <h3>SAML</h3>
+  <table class="table table-striped">
+    <tbody>
+      <tr>
+        <td>Certificate</td>
+        <td>
+          <textarea name="setting[saml_certificate]" class="form-control"><%= Setting.saml_certificate %></textarea>
+          <%- if Setting.saml_certificate.present? %>
+            <%- cert = OpenSSL::X509::Certificate.new(Setting.saml_certificate) %>
+            <p class="small">Certificate Fingerprint: <%= OpenSSL::Digest::SHA1.hexdigest(cert.to_der).scan(/../).join(':').upcase %></p>
+          <%- end %>
+        </td>
+      </tr>
+
+      <tr>
+        <td>Key</td>
+        <td>
+          <textarea name="setting[saml_key]" class="form-control"><%= Setting.saml_key %></textarea>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <button class="btn btn-primary">Save</button>
+<%- end %>

--- a/app/views/admin/settings/templates.html.erb
+++ b/app/views/admin/settings/templates.html.erb
@@ -1,0 +1,30 @@
+<%= form_tag({controller: "settings", action: "update"}, method: :post, class: "form") do |form| %>
+  <h1>Templates</h1>
+  <table class="table table-striped">
+    <tr>
+      <td>Home page template</td>
+      <td>
+        <textarea name="setting[home_template]" class="form-control" ><%= Setting.home_template %></textarea>
+      </td>
+    </tr>
+    <tr>
+      <td>Registered home page template</td>
+      <td>
+        <textarea name="setting[registered_home_template]" class="form-control" ><%= Setting.registered_home_template %></textarea>
+      </td>
+    </tr>
+    <tr>
+      <td>Password reset email template</td>
+      <td>
+        <textarea name="setting[admin_reset_email_template]" class="form-control" ><%= Setting.admin_reset_email_template %></textarea>
+      </td>
+    </tr>
+    <tr>
+      <td>Admin created user welcome template</td>
+      <td>
+        <textarea name="setting[admin_welcome_email_template]" class="form-control" ><%= Setting.admin_welcome_email_template %></textarea>
+      </td>
+    </tr>
+  </table>
+  <button class="btn btn-primary">Save</button>
+<%- end %>

--- a/app/views/layouts/_admin_nav.html.erb
+++ b/app/views/layouts/_admin_nav.html.erb
@@ -5,5 +5,9 @@
   <%= nav_link "#{fa_icon("openid")} OpenID Connect Application".html_safe, admin_applications_path %>
   <%= nav_link "#{fa_icon("lock")} Saml Service Providers".html_safe, admin_saml_service_providers_path %>
   <%= nav_link "#{fa_icon("gear")} Settings".html_safe, admin_settings_path %>
+    <%= nav_link "- Branding", admin_settings_branding_path %>
+    <%= nav_link "- Templates", admin_settings_templates_path %>
+    <%= nav_link "- OpenID Connect", admin_settings_openid_connect_path %>
+    <%= nav_link "- SAML", admin_settings_saml_path %>
   <%= nav_link "#{fa_icon("tasks")} Permissions".html_safe, admin_permissions_path %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,12 @@ Rails.application.routes.draw do
     resources :saml_service_providers
     get :settings, to: 'settings#index'
     post :settings, to: 'settings#update'
+    # namespace :settings do
+    get 'settings/openid_connect', to: 'settings#openid_connect'
+    get 'settings/saml', to: 'settings#saml'
+    get 'settings/branding', to: 'settings#branding'
+    get 'settings/templates', to: 'settings#templates'
+    # end
   end
 
   devise_for :users, controllers: {

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Admin::SettingsController, type: :controller do
         render_views
         it 'Shows the SAML certificate fingerprint' do
           Setting.saml_certificate = File.read('myCert.crt')
-          get :index
+          get :saml
           expect(response.body).to include('4C:51:74:2D:C7:00:32:1A:87:79:AD:B8:1D:D8:8A:66:0C:FB:73:F3')
         end
       end


### PR DESCRIPTION
By having separate sections for the different types of
settings, an administrator has a better experience
with managing EyeDP.

Closes #140