### PR TITLE
Resolve conflict between setting and devise dynamic methods

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -37,15 +37,15 @@ class Admin::SettingsController < AdminController
                           else # rubocop:disable Style/EmptyElse
                             nil
                           end
-    opts[:reset_password_within] = if opts[:reset_password_within].present?
-                                     opts[:reset_password_within].to_i.days
-                                   # The below else is ignored because we need to
-                                   # ensure that opts[:expire_after] is nil rather
-                                   # than an empty string so that the expiration is
-                                   # disabled!
-                                   else
-                                     7.days
-                                   end
+    opts[:devise_reset_password_within] = if opts[:devise_reset_password_within].present?
+                                            opts[:devise_reset_password_within].to_i.days
+                                          # The below else is ignored because we need to
+                                          # ensure that opts[:expire_after] is nil rather
+                                          # than an empty string so that the expiration is
+                                          # disabled!
+                                          else
+                                            7.days
+                                          end
     opts.each do |setting, value|
       Setting.send("#{setting}=", value)
     end
@@ -63,7 +63,7 @@ class Admin::SettingsController < AdminController
   def setting_params # rubocop:disable Metrics/MethodLength
     params.fetch(:setting, {}).permit(
       :idp_base, :html_title_base,
-      :reset_password_within,
+      :devise_reset_password_within,
       :saml_certificate, :saml_key,
       :oidc_signing_key,
       :registration_enabled, :permemant_username,

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -151,7 +151,7 @@ class Setting < ApplicationRecord
   field :logo
   field :logo_height, default: 50, type: :integer
   field :logo_width, default: 100, type: :integer
-  field :reset_password_within, type: :time, default: 7.days.iso8601
+  field :devise_reset_password_within, type: :time, default: 7.days.iso8601
 
   field :home_template, default: '', type: :string
   field :registered_home_template, default: '', type: :string

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -20,7 +20,7 @@
     </tr>
     <tr>
       <td>Reset Password Within</td>
-      <td><input type="text" name="setting[reset_password_within]" class="form-control" value="<%= Setting.reset_password_within.parts[:days] if Setting.reset_password_within %>"/>
+      <td><input type="text" name="setting[devise_reset_password_within]" class="form-control" value="<%= Setting.devise_reset_password_within.parts[:days] if Setting.devise_reset_password_within %>"/>
         <p class="small">How many days to allow a password reset token to be valid.</p></td>
     </tr>
     <!-- Logo settings -->

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -219,9 +219,9 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  #config.reset_password_within = 6.hours
+  # config.reset_password_within = 6.hours
   def config.reset_password_within
-    Setting.reset_password_within
+    Setting.devise_reset_password_within
   end
 
   # When set to false, does not sign a user in automatically after their password is

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -98,10 +98,10 @@ RSpec.describe Admin::SettingsController, type: :controller do
         end
 
         it 'can update the password reset token validity' do
-          expect(Setting.reset_password_within).to eq 7.days
+          expect(Setting.devise_reset_password_within).to eq 7.days
           expect(Devise.reset_password_within).to eq 7.days
-          post(:update, params: { setting: { reset_password_within: '30' } })
-          expect(Setting.reset_password_within).to eq 30.days
+          post(:update, params: { setting: { devise_reset_password_within: '30' } })
+          expect(Setting.devise_reset_password_within).to eq 30.days
           expect(Devise.reset_password_within).to eq 30.days
         end
       end

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Devise::PasswordsController do
+  include DeviseHelpers
+
+  before do
+    set_devise_mapping(context: @request)
+  end
+
+  describe '#update' do
+    render_views
+
+    context 'updating the password' do
+      subject do
+        put :update, params: {
+          user: {
+            password: password,
+            password_confirmation: password_confirmation,
+            reset_password_token: reset_password_token
+          }
+        }
+      end
+
+      let(:password) { 'test1234' }
+      let(:password_confirmation) { password }
+      let(:reset_password_token) { user.send(:set_reset_password_token) }
+      let(:user) { User.create!(username: 'example', email: 'test@localhost', password: 'test1234') }
+
+      context 'password update is successful' do
+        it 'updates the password-related flags' do
+          subject
+          user.reload
+
+          expect(response).to redirect_to(new_user_session_path)
+          expect(flash[:notice]).to include('password has been changed successfully')
+        end
+      end
+
+      context 'password update is unsuccessful' do
+        let(:password_confirmation) { 'not_the_same_as_password' }
+
+        it 'does not update the password-related flags' do
+          subject
+          user.reload
+
+          expect(response.body).to include('Password confirmation doesn&#39;t match Password')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With Setting and Devise sharing the method named `reset_password_within`,
attempts to validate a User's reset token validity would fail when
attempting to call `_value_of` on a User (finally failing when calling
it on an ApplicationRecord (abstract)). By renaming the Setting to
`devise_reset_password_within`, this conflict is avoided and Devise
can successfully check the reset token validity.

Closes #175