### PR TITLE
Updates to resolve deprecations and warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'devise_fido_usf'
 gem 'devise-i18n'
 gem 'friendly_id'
 # Do TOTP 2FA
-gem 'devise-two-factor'
+gem 'devise-two-factor', github: 'centaurisolutions/devise-two-factor'
 gem 'rqrcode'
 
 # Translations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/centaurisolutions/devise-two-factor.git
+  revision: cf43ea1367fb30c738de416be59616a76098c226
+  specs:
+    devise-two-factor (3.1.1)
+      activesupport (< 6.2)
+      attr_encrypted (>= 1.3, < 4, != 2)
+      devise (~> 4.0)
+      railties (< 6.2)
+      rotp (~> 6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -138,12 +149,6 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.2)
       devise (>= 4.7.1)
-    devise-two-factor (3.0.0)
-      activesupport
-      attr_encrypted (>= 1.3, < 4, != 2)
-      devise (~> 4.0)
-      railties
-      rotp (~> 2.0)
     devise_fido_usf (0.1.11)
       devise (>= 3.2)
       rails (>= 4.2)
@@ -312,7 +317,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
-    rotp (2.1.2)
+    rotp (6.2.0)
     rqrcode (1.2.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.2)
@@ -452,7 +457,7 @@ DEPENDENCIES
   database_cleaner-active_record
   devise
   devise-i18n
-  devise-two-factor
+  devise-two-factor!
   devise_fido_usf
   doorkeeper
   doorkeeper-openid_connect

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,11 @@ Bundler.require(*Rails.groups)
 module EyedP
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
+
+    # The new autoloader (Zeitwerk) in the 6.0 defaults breaks some of the Devise
+    # issues, so it's a TODO to resolve the below autoloading issues.
+    config.autoloader = :classic
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SessionsController do
               name: 'test', key_handle: 'test', public_key: 'test', certificate: 'test',
               last_authenticated_at: Time.zone.now
             )
-            expect { post(:create, params: { user: user_params }) }.not_to raise_error(ActionView::Template::Error)
+            expect { post(:create, params: { user: user_params }) }.not_to raise_error
             expect(response.status).to eq(200)
           end
         end


### PR DESCRIPTION
There were several deprecation notices in the test output
so this change is an update to remove those. Additionally,
there was a warning about possible false negatives in the
controller testing as a result of being too specific in
what exceptions are not expected to be raised so that was
resolved as well.