### PR TITLE
Add support for operator and manager roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ To report sensitive or security issues, we prefer that confidential issues be cr
     - [SAML with Gitlab](#saml-with-gitlab)
     - [SAML with Rocket.Chat](#saml-with-rocketchat)
   + [Nginx Auth Request](#nginx-auth-request)
+- [Management](#management)
+  + [Operators](#operators)
+  + [Managers](#managers)
+  + [Administrators](#administrators)
 - [Development](#development)
 
 ## Overview
@@ -334,6 +338,39 @@ that may not have their own acess controls at the Nginx layer. To learn more
 about how to use it, an admin should peruse the [groups](#groups) section of
 the documentetion.
 
+## Management
+
+Managing an identity provider can be a complex task requiring many different
+types of users. 
+
+### Operators
+
+An operator is a type of user that can manage EyeDP itself, but cannot manage
+users or groups. A user becomes an operator when they're added to a group that
+has the operator flag enabled, which can be done in the admin UI by an
+administrator.
+
+### Managers
+
+An operator is a type of user that can manage users and groups, but cannot
+manage EyeDP. A user becomes a manager when they're added to a group that
+has the manager flag enabled, which can be done in the admin UI by an
+administrator.
+
+A manager cannot add or remove a user from an operator or administrator group,
+nor change those flags on other groups. A manager user can add and remove
+additional managers.
+
+### Administrators
+
+A user becomes an administrator when they're added to a group that
+has the admin flag enabled, which can be done in the admin UI by an
+administrator.
+
+An administrator has no restrictions on the actions that they can perform, so
+should be a small group of users. An administrator account is needed to change
+membvership in administrator and operator groups, as well as creating and
+managing these group types.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -350,9 +350,14 @@ users or groups. A user becomes an operator when they're added to a group that
 has the operator flag enabled, which can be done in the admin UI by an
 administrator.
 
+In this context, managing EyeDP means that an operator can manage SSO
+applications such as OpenID Connect and SAML applications. In additional, they
+can change EyeDP's settings, such as key data for the IdP, hostnames, and
+templates.
+
 ### Managers
 
-An operator is a type of user that can manage users and groups, but cannot
+A manager is a type of user that can manage users and groups, but cannot
 manage EyeDP. A user becomes a manager when they're added to a group that
 has the manager flag enabled, which can be done in the admin UI by an
 administrator.

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -23,7 +23,7 @@ class Admin::ApplicationsController < AdminController
   end
 
   def ensure_user_is_authorized!
-    raise(ActionController::RoutingError, 'Not Found') and return \
+    raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin? || current_user&.operator?
   end
 end

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -21,4 +21,9 @@ class Admin::ApplicationsController < AdminController
       :redirect_uri, :confidential
     )
   end
+
+  def ensure_user_is_authorized!
+    raise(ActionController::RoutingError, 'Not Found') and return \
+      unless current_user&.admin? || current_user&.operator?
+  end
 end

--- a/app/controllers/admin/audits_controller.rb
+++ b/app/controllers/admin/audits_controller.rb
@@ -10,4 +10,9 @@ class Admin::AuditsController < AdminController
   def whitelist_attributes
     %w[auditable_type audited_changes]
   end
+
+  def ensure_user_is_authorized!
+    raise(ActionController::RoutingError, 'Not Found') \
+      unless current_user&.admin?
+  end
 end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -85,7 +85,7 @@ class Admin::GroupsController < AdminController
   end
 
   def ensure_user_is_authorized!
-    raise(ActionController::RoutingError, 'Not Found') and return \
+    raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin? || current_user&.manager?
   end
 end

--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -34,7 +34,7 @@ class Admin::PermissionsController < AdminController
   end
 
   def ensure_user_is_authorized!
-    raise(ActionController::RoutingError, 'Not Found') and return \
+    raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin? || current_user&.operator?
   end
 end

--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -32,4 +32,9 @@ class Admin::PermissionsController < AdminController
   def model_params
     params.require(:permission).permit(:name, :description)
   end
+
+  def ensure_user_is_authorized!
+    raise(ActionController::RoutingError, 'Not Found') and return \
+      unless current_user&.admin? || current_user&.operator?
+  end
 end

--- a/app/controllers/admin/saml_service_providers_controller.rb
+++ b/app/controllers/admin/saml_service_providers_controller.rb
@@ -33,7 +33,7 @@ class Admin::SamlServiceProvidersController < AdminController
   end
 
   def ensure_user_is_authorized!
-    raise(ActionController::RoutingError, 'Not Found') and return \
+    raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin? || current_user&.operator?
   end
 end

--- a/app/controllers/admin/saml_service_providers_controller.rb
+++ b/app/controllers/admin/saml_service_providers_controller.rb
@@ -31,4 +31,9 @@ class Admin::SamlServiceProvidersController < AdminController
     p[:response_hosts] = p[:response_hosts].split(/ +/) if p[:response_hosts]
     p
   end
+
+  def ensure_user_is_authorized!
+    raise(ActionController::RoutingError, 'Not Found') and return \
+      unless current_user&.admin? || current_user&.operator?
+  end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -73,4 +73,9 @@ class Admin::SettingsController < AdminController
       :admin_reset_email_template, :admin_welcome_email_template
     )
   end
+
+  def ensure_user_is_authorized!
+    raise(ActionController::RoutingError, 'Not Found') and return \
+      unless current_user&.admin? || current_user&.operator?
+  end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -75,7 +75,7 @@ class Admin::SettingsController < AdminController
   end
 
   def ensure_user_is_authorized!
-    raise(ActionController::RoutingError, 'Not Found') and return \
+    raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin? || current_user&.operator?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -108,7 +108,7 @@ class Admin::UsersController < AdminController
   end
 
   def ensure_user_is_authorized!
-    raise(ActionController::RoutingError, 'Not Found') and return \
+    raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin? || current_user&.manager?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -72,8 +72,8 @@ class Admin::UsersController < AdminController
       :password, :last_activity_at, group_ids: []
     )
     p[:group_ids] ||= []
-    # A Manager cannot add a user to an operator or admin group
     if current_user.manager?
+      # A Manager cannot add a user to an operator or admin group
       p[:group_ids] -= Group.where(admin: true).or(Group.where(operator: true)).pluck(:id)
       # A manager cannot remove admin from an admin user nor operator from an operator user
       p[:group_ids] += @model.groups.where(admin: true).or(Group.where(operator: true)).pluck(:id)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -54,11 +54,11 @@ class Admin::UsersController < AdminController
   end
 
   def show_whitelist_attributes
-    %w[email name username two_factor_enabled? groups expires_at last_activity_at]
+    %w[email name username two_factor_enabled? groups roles expires_at last_activity_at]
   end
 
   def whitelist_attributes
-    %w[email username name two_factor_enabled? groups expired?]
+    %w[email username name two_factor_enabled? groups roles expired?]
   end
 
   def model
@@ -66,12 +66,18 @@ class Admin::UsersController < AdminController
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
-  def model_params
+  def model_params # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     p = params.require(:user).permit(
       :email, :username, :email, :name, :expires_at,
       :password, :last_activity_at, group_ids: []
     )
     p[:group_ids] ||= []
+    # A Manager cannot add a user to an operator or admin group
+    if current_user.manager?
+      p[:group_ids] -= Group.where(admin: true).or(Group.where(operator: true)).pluck(:id)
+      # A manager cannot remove admin from an admin user nor operator from an operator user
+      p[:group_ids] += @model.groups.where(admin: true).or(Group.where(operator: true)).pluck(:id)
+    end
     p.delete(:password) if p[:password] && p[:password].empty?
     p
   end
@@ -99,5 +105,10 @@ class Admin::UsersController < AdminController
 
   def custom_userdata_params
     params.require(:custom_data).permit!
+  end
+
+  def ensure_user_is_authorized!
+    raise(ActionController::RoutingError, 'Not Found') and return \
+      unless current_user&.admin? || current_user&.manager?
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,7 +2,7 @@
 
 class AdminController < ApplicationController # rubocop:disable Metrics/ClassLength
   # before_action :authenticate_user!
-  before_action :ensure_user_is_admin!
+  before_action :ensure_user_is_authorized!
   before_action :set_model, only: %i[show edit update destroy]
   # GET /admin/#{model}
   # GET /admin/#{model}.json
@@ -149,8 +149,8 @@ class AdminController < ApplicationController # rubocop:disable Metrics/ClassLen
     @model = model.find(params[:id])
   end
 
-  def ensure_user_is_admin!
+  def ensure_user_is_authorized! # rubocop:disable Metrics/CyclomaticComplexity
     raise(ActionController::RoutingError, 'Not Found') and return \
-      unless current_user&.admin?
+      unless current_user&.admin? || current_user&.operator? || current_user&.manager?
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -149,8 +149,8 @@ class AdminController < ApplicationController # rubocop:disable Metrics/ClassLen
     @model = model.find(params[:id])
   end
 
-  def ensure_user_is_authorized! # rubocop:disable Metrics/CyclomaticComplexity
-    raise(ActionController::RoutingError, 'Not Found') and return \
+  def ensure_user_is_authorized!
+    raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin? || current_user&.operator? || current_user&.manager?
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -76,4 +76,12 @@ class Group < ApplicationRecord
   def rendered_welcome_email(user = nil)
     template.render(template_variables(user))
   end
+
+  def roles
+    @roles ||= begin
+      %i{admin manager operator}.filter do |name|
+        self.send(name)
+      end
+    end
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -79,8 +79,8 @@ class Group < ApplicationRecord
 
   def roles
     @roles ||= begin
-      %i{admin manager operator}.filter do |name|
-        self.send(name)
+      %i[admin manager operator].filter do |name|
+        send(name)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,7 +151,15 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def admin?
-    @admin ||= asserted_groups.where(admin: true).present?
+    roles.include?(:admin)
+  end
+
+  def manager?
+    roles.include?(:manager)
+  end
+
+  def operator?
+    roles.include?(:operator)
   end
 
   def to_s
@@ -161,9 +169,9 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   #   %i[awesome internal]
   # end
 
-  # def roles
-  #   %i[admin staff]
-  # end
+  def roles
+    asserted_groups.map(&:roles).flatten.uniq
+  end
 
   def login
     @login || username || email

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -44,6 +44,26 @@
   <div class="form-group">
     <div class="row">
       <div class="col-sm-2">
+        <%= form.label :roles %>
+      </div>
+      <div class="col-sm-10">
+        <div>
+          <%= form.check_box :manager %> Manager
+        </div>
+        <%- if current_user.admin? %>
+          <div>
+            <%= form.check_box :operator %> Operator
+          </div><div>
+            <%= form.check_box :admin %> Admin
+          </div>
+        <%- end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-2">
         <%= form.label :groups %>
       </div>
       <div class="col-sm-10">

--- a/app/views/layouts/_admin_nav.html.erb
+++ b/app/views/layouts/_admin_nav.html.erb
@@ -1,9 +1,12 @@
 <ul class="nav flex-column">
   <%= nav_link "#{fa_icon("dashboard")} Dashboard".html_safe, admin_dashboard_path %>
+  <%- if current_user.admin? || current_user.manager? %>
   <%= nav_link "#{fa_icon("user")} Users".html_safe, admin_users_path %>
   <%= nav_link "#{fa_icon("users")} Groups".html_safe, admin_groups_path %>
-  <%= nav_link "#{fa_icon("openid")} OpenID Connect Application".html_safe, admin_applications_path %>
-  <%= nav_link "#{fa_icon("lock")} Saml Service Providers".html_safe, admin_saml_service_providers_path %>
+  <% end %>
+  <%- if current_user.admin? || current_user.operator? %>
+    <%= nav_link "#{fa_icon("openid")} OpenID Connect Application".html_safe, admin_applications_path %>
+    <%= nav_link "#{fa_icon("lock")} Saml Service Providers".html_safe, admin_saml_service_providers_path %>
   <%= nav_link "#{fa_icon("gear")} Settings".html_safe, admin_settings_path %>
     <%= nav_link "- Branding", admin_settings_branding_path %>
     <%= nav_link "- Custom User Data", admin_custom_userdata_types_path %>
@@ -11,7 +14,8 @@
     <%= nav_link "- Templates", admin_settings_templates_path %>
     <%= nav_link "- OpenID Connect", admin_settings_openid_connect_path %>
     <%= nav_link "- SAML", admin_settings_saml_path %>
-  <%= nav_link "#{fa_icon("tasks")} Permissions".html_safe, admin_permissions_path %>
+    <%= nav_link "#{fa_icon("tasks")} Permissions".html_safe, admin_permissions_path %>
+  <%- end %>
   <%= nav_link "#{fa_icon("commenting")} Audit Log".html_safe, admin_audits_path %>
 
 </ul>

--- a/app/views/layouts/_admin_nav.html.erb
+++ b/app/views/layouts/_admin_nav.html.erb
@@ -7,7 +7,7 @@
   <%- if current_user.admin? || current_user.operator? %>
     <%= nav_link "#{fa_icon("openid")} OpenID Connect Application".html_safe, admin_applications_path %>
     <%= nav_link "#{fa_icon("lock")} Saml Service Providers".html_safe, admin_saml_service_providers_path %>
-  <%= nav_link "#{fa_icon("gear")} Settings".html_safe, admin_settings_path %>
+    <%= nav_link "#{fa_icon("gear")} Settings".html_safe, admin_settings_path %>
     <%= nav_link "- Branding", admin_settings_branding_path %>
     <%= nav_link "- Custom User Data", admin_custom_userdata_types_path %>
     <%= nav_link "- Custom Group Data", admin_custom_group_data_types_path %>
@@ -16,6 +16,8 @@
     <%= nav_link "- SAML", admin_settings_saml_path %>
     <%= nav_link "#{fa_icon("tasks")} Permissions".html_safe, admin_permissions_path %>
   <%- end %>
-  <%= nav_link "#{fa_icon("commenting")} Audit Log".html_safe, admin_audits_path %>
+  <%- if current_user.admin? %>
+    <%= nav_link "#{fa_icon("commenting")} Audit Log".html_safe, admin_audits_path %>
+  <%- end %>
 
 </ul>

--- a/db/migrate/20210223071108_add_more_roles_to_group.rb
+++ b/db/migrate/20210223071108_add_more_roles_to_group.rb
@@ -1,0 +1,6 @@
+class AddMoreRolesToGroup < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groups, :manager, :boolean, default: false
+    add_column :groups, :operator, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_10_140728) do
+ActiveRecord::Schema.define(version: 2021_02_23_071108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -131,6 +131,8 @@ ActiveRecord::Schema.define(version: 2021_02_10_140728) do
     t.boolean "requires_2fa", default: false
     t.text "description"
     t.boolean "admin", default: false
+    t.boolean "manager", default: false
+    t.boolean "operator", default: false
     t.index ["parent_id"], name: "index_groups_on_parent_id"
   end
 

--- a/spec/controllers/admin/applications_controller_spec.rb
+++ b/spec/controllers/admin/applications_controller_spec.rb
@@ -17,6 +17,41 @@ RSpec.describe Admin::ApplicationsController, type: :controller do
   end
 
   describe 'Application' do
+    context 'signed in manager' do
+      let(:manager_group) { Group.create!(name: 'managers', manager: true) }
+      let(:manager) do
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user.groups << manager_group
+        user
+      end
+
+      before do
+        sign_in(manager)
+      end
+
+      it 'Shows the index page' do
+        expect { get :index }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context 'signed in operator' do
+      let(:operator_group) { Group.create!(name: 'operators', operator: true) }
+      let(:operator) do
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user.groups << operator_group
+        user
+      end
+
+      before do
+        sign_in(operator)
+      end
+
+      it 'Shows the index page' do
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+
     context 'signed in admin' do
       before do
         sign_in(admin)

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -12,6 +12,42 @@ RSpec.describe Admin::DashboardController, type: :controller do
   end
 
   describe 'Dashboard' do
+    context 'signed in manager' do
+      let(:manager_group) { Group.create!(name: 'managers', manager: true) }
+      let(:manager) do
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user.groups << manager_group
+        user
+      end
+
+      before do
+        sign_in(manager)
+      end
+
+      it 'Shows the index page' do
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'signed in operator' do
+      let(:operator_group) { Group.create!(name: 'operators', operator: true) }
+      let(:operator) do
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user.groups << operator_group
+        user
+      end
+
+      before do
+        sign_in(operator)
+      end
+
+      it 'Shows the index page' do
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+
     context 'signed in admin' do
       before do
         sign_in(admin)

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -14,6 +14,41 @@ RSpec.describe Admin::GroupsController, type: :controller do
   end
 
   describe 'Group' do
+    context 'signed in manager' do
+      let(:manager_group) { Group.create!(name: 'managers', manager: true) }
+      let(:manager) do
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user.groups << manager_group
+        user
+      end
+
+      before do
+        sign_in(manager)
+      end
+
+      it 'Shows the index page' do
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'signed in operator' do
+      let(:operator_group) { Group.create!(name: 'operators', operator: true) }
+      let(:operator) do
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user.groups << operator_group
+        user
+      end
+
+      before do
+        sign_in(operator)
+      end
+
+      it 'Shows the index page' do
+        expect { get :index }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
     context 'signed in admin' do
       before do
         sign_in(admin)

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -17,6 +17,41 @@ RSpec.describe Admin::SettingsController, type: :controller do
   end
 
   describe 'User' do
+    context 'signed in manager' do
+      let(:manager_group) { Group.create!(name: 'managers', manager: true) }
+      let(:manager) do
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user.groups << manager_group
+        user
+      end
+
+      before do
+        sign_in(manager)
+      end
+
+      it 'Shows the index page' do
+        expect { get :index }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context 'signed in operator' do
+      let(:operator_group) { Group.create!(name: 'operators', operator: true) }
+      let(:operator) do
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user.groups << operator_group
+        user
+      end
+
+      before do
+        sign_in(operator)
+      end
+
+      it 'Shows the index page' do
+        get :index
+        expect(response.status).to eq(200)
+      end
+    end
+
     context 'signed in admin' do
       before do
         sign_in(admin)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,12 +32,27 @@ RSpec.describe User, type: :model do
 
   let(:user) { User.create!(username: 'example', email: 'test@localhost', password: 'test1234') }
   let(:group) { Group.create!(name: 'administrators', admin: true) }
+  let(:operator_group) { Group.create!(name: 'operators', operator: true) }
+  let(:manager_group) { Group.create!(name: 'managers', manager: true) }
 
   it { should be_audited }
 
   it 'makes a user Admin is it has membership' do
+    expect(user.admin?).to be false
     user.groups << group
     expect(user.admin?).to be true
+  end
+
+  it 'makes a user Operator if it has membership' do
+    expect(user.operator?).to be false
+    user.groups << operator_group
+    expect(user.operator?).to be true
+  end
+
+  it 'makes the user Manager if it has membership' do
+    expect(user.manager?).to be false
+    user.groups << manager_group
+    expect(user.manager?).to be true
   end
 
   it 'does not grant admin just because of a group name' do


### PR DESCRIPTION
Broadly, the new roles work as follows:

The manager role is a role that manages users and groups, with the
notable exception that a Manager cannot add or remove the Operator
and Admin attributes on a group, nor add those groups to a user.
In effect, this means that a Manager can only add or remove a useri
from non-permission granting groups, or to the Manager group.

The operator role is a role designed to help with management of
EyeDP itself, granting no control of users not groups, but allowing
changing Settings and Identity Service Providers. This means that
an Operator can create and edit SAML or OpenID Connect Applications,
and they can manage Certificates for the same, as well as updating
Settings such as the application's base URI or templates for emails.

Ad admin continues to have full permission for all activities.

Closes: #199