### PR TITLE
Improve handling of OpenID Connect Application

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,14 +1,52 @@
 # frozen_string_literal: true
 
 class Admin::ApplicationsController < AdminController
+  def index
+    super
+    session[:show_secret] = nil
+  end
+
+  def show
+    @show_secret = session[:show_secret]
+    session[:show_secret] = nil
+    super
+  end
+
+  def edit
+    @show_secret = session[:show_secret]
+    session[:show_secret] = nil
+    super
+  end
+
+  def create
+    super
+    session[:show_secret] = true
+  end
+
+  def renew_secret
+    @model = Application.find(params[:application_id])
+    @model.renew_secret
+    session[:show_secret] = true
+    @model.save
+    respond_to do |format|
+      format.html { redirect_to [:admin, @model], notice: 'Secret was successfully rotated' }
+      format.json { render :show, status: :ok, location: [:admin, @model] }
+    end
+  end
+
   private
 
+  def application_attributes
+    %w[name display_url uid secret internal redirect_uri scopes confidential]
+  end
+  helper_method :application_attributes
+
   def model_attributes
-    %w[name display_url uid internal secret redirect_uri scopes confidential]
+    %w[name display_url uid internal redirect_uri scopes confidential]
   end
 
   def new_fields
-    %w[name display_url uid internal secret redirect_uri scopes confidential]
+    %w[name display_url internal redirect_uri scopes confidential]
   end
 
   def model
@@ -17,7 +55,7 @@ class Admin::ApplicationsController < AdminController
 
   def model_params
     params.require('application').permit(
-      :name, :display_url, :uid, :internal, :secret, :scopes,
+      :name, :display_url, :internal, :scopes,
       :redirect_uri, :confidential
     )
   end

--- a/app/views/admin/_form.html.erb
+++ b/app/views/admin/_form.html.erb
@@ -46,7 +46,7 @@
     </div>
   <%- end %>
 
-  <%= render partial: 'sub_form', locals: { model: model, form: form } %>
+  <%= render partial: 'sub_form', locals: { model: model, form: form, new_model: new_model } %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/admin/applications/_sub_form.html.erb
+++ b/app/views/admin/applications/_sub_form.html.erb
@@ -1,0 +1,19 @@
+
+<%- if not new_model %>
+  <div class="form-group">
+    <div class="row">
+      <div class="col-sm-2">
+        <Label>Secret</Label>
+      </div>
+      <div class="col-sm-10">
+        <%- if @show_secret %>
+          <%- value = model.secret %>
+        <%- else %>
+          <%- value = '*' * 30 %>
+        <%- end %>
+        <%= form.text_field :secret, value: value, class: 'form-control', disabled: true %>
+        <%= link_to 'Renew Secret', [:admin, model, :renew_secret], method: :post, data: { confirm: 'Are you sure? Rotating an Application secret requires updating all users of the secret'}, class: "btn btn-warning"  %>
+      </div>
+    </div>
+  </div>
+<%- end %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -1,0 +1,46 @@
+<h2><%= @model.class.name %> <%= @model %></h2>
+<%= render partial: 'sub_heading' %>
+<div class="row">
+  <%= link_to 'Edit', ['edit', :admin, @model] %> |
+  <%= link_to 'Back', [:admin, @model.class] %> |
+  <%= link_to 'Renew Secret', [:admin, @model, :renew_secret], method: :post, data: { confirm: 'Are you sure? Rotating an Application secret requires updating all users of the secret'}%>
+</div>
+
+<div class="row">
+  <dl>
+    <%- application_attributes.each do |attribute| %>
+      <dt><%= attribute %></dt>
+      <dd>
+        <%- data = @model.send(attribute) %>
+        <%- if data.is_a? ActiveRecord::Associations::CollectionProxy %>
+          <ul>
+            <%-data.each do |row| %>
+              <li><%= row %></li>
+            <%- end %>
+          </ul>
+        <%- else %>
+          <%- if attribute == 'secret' %>
+            <%- unless @show_secret %>
+                <%- data = '*' * 30 %>
+            <%- end %>
+          <%- end %>
+          <%- if attribute == 'secret' && @show_secret %>
+            <div class="alert alert-danger">
+              This secret will only be displayed once, copy it to another location to use!
+            </div>
+          <%- end %>
+          <%= data %>
+        <%- end %>
+      </dd>
+    <%- end %>
+  </dl>
+</div>
+
+<% begin %>
+  <hr />
+  <div class="row">
+    <%= render partial: 'show' %>
+  </div>
+<% rescue ActionView::MissingTemplate %>
+<% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,9 @@ Rails.application.routes.draw do
     resources :custom_userdata_types
     resources :custom_group_data_types
     resources :permissions
-    resources :applications
+    resources :applications do
+      post :renew_secret, to: 'applications#renew_secret'
+    end
     resources :saml_service_providers
     resources :audits, only: %i[index show]
     get :settings, to: 'settings#index'

--- a/spec/controllers/admin/applications_controller_spec.rb
+++ b/spec/controllers/admin/applications_controller_spec.rb
@@ -69,6 +69,62 @@ RSpec.describe Admin::ApplicationsController, type: :controller do
           app.reload
           expect(app.display_url).to eq('test.com')
         end
+
+        it 'cannot edit the secret' do
+          secret = app.secret
+          post(:update, params: { id: app.id, application: { secret: 'fake secret' } })
+          app.reload
+          expect(app.secret).to eq(secret)
+        end
+
+        it 'cannot edit the UID' do
+          uid = app.uid
+          post(:update, params: { id: app.id, application: { uid: 'fake uid' } })
+          app.reload
+          expect(app.uid).to eq(uid)
+        end
+      end
+
+      context 'Secrets' do
+        render_views
+
+        it 'does not show the secret on show' do
+          get(:show, params: { id: app.id })
+          expect(response.body).to match(
+            %r{<dt>secret</dt>\s+<dd>\s+\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*}
+          )
+          expect(response.body).not_to include(app.secret)
+        end
+
+        it 'does not show the secret on edit' do
+          get(:edit, params: { id: app.id })
+          expect(response.body).to include(
+            '<input value="******************************" class="form-control" disabled="disabled" ' \
+            'type="text" name="application[secret]" id="application_secret" />'
+          )
+          expect(response.body).not_to include(app.secret)
+        end
+
+        it 'shows the secret after renewing secret on show' do
+          post(:renew_secret, params: { application_id: app.id })
+          get(:show, params: { id: app.id })
+          app.reload
+          expect(response.body).to include(app.secret)
+        end
+
+        it 'shows the secret after renewing secret on edit' do
+          post(:renew_secret, params: { application_id: app.id })
+          get(:edit, params: { id: app.id })
+          app.reload
+          expect(response.body).to include(app.secret)
+        end
+
+        it 'shows the secret after create' do
+          post(:create, params: { application: { name: 'test', redirect_uri: 'https://example.com' } })
+          application = Application.first
+          get(:show, params: { id: application.id })
+          expect(response.body).to include(application.secret)
+        end
       end
     end
 


### PR DESCRIPTION
This change includes a few pieces that contribute to the change:

1. Removing the ability to manually set Application secret / UID
2. Only showing the secret once after it's created / updated
3. Allowing an admin to renew the secret

Closes #204