### PR TITLE
Fix up Setting updating with optional update params

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -16,36 +16,12 @@ class Admin::SettingsController < AdminController
 
   # PATCH/PUT /admin/settings/1
   # PATCH/PUT /admin/settings/1.json
-  def update # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+  def update # rubocop:disable Metrics/AbcSize
     opts = setting_params
-    opts[:registration_enabled] = if opts[:registration_enabled].nil?
-                                    false
-                                  else
-                                    true
-                                  end
-    opts[:permanent_email] = if opts[:permanent_email].nil?
-                               false
-                             else
-                               true
-                             end
-    opts[:expire_after] = if opts[:expire_after].present?
-                            opts[:expire_after].to_i.days
-                          # The below else is ignored because we need to
-                          # ensure that opts[:expire_after] is nil rather
-                          # than an empty string so that the expiration is
-                          # disabled!
-                          else # rubocop:disable Style/EmptyElse
-                            nil
-                          end
-    opts[:devise_reset_password_within] = if opts[:devise_reset_password_within].present?
-                                            opts[:devise_reset_password_within].to_i.days
-                                          # The below else is ignored because we need to
-                                          # ensure that opts[:expire_after] is nil rather
-                                          # than an empty string so that the expiration is
-                                          # disabled!
-                                          else
-                                            7.days
-                                          end
+    opts[:expire_after] = opts[:expire_after].to_i.days unless opts[:expire_after].nil?
+    opts[:expire_after] = nil if opts[:expire_after].present? && opts[:expire_after] == 0.days
+    opts[:devise_reset_password_within] = opts[:devise_reset_password_within].to_i.days \
+      if opts[:devise_reset_password_within].present?
     opts.each do |setting, value|
       Setting.send("#{setting}=", value)
     end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -7,7 +7,11 @@
     </tr>
     <tr>
       <td>Enable User Registration</td>
-      <td><input type="checkbox" name="setting[registration_enabled]" class="form-control" <% if Setting.registration_enabled %>checked <% end %> value="" /></td>
+      <td>
+        <% # The hidden field below allows sending a false value if the checkbox is empty (false) %>
+        <input type="hidden" name="setting[registration_enabled]" value="false" />
+        <input type="checkbox" name="setting[registration_enabled]" class="form-control" <% if Setting.registration_enabled %>checked <% end %> value="true" />
+      </td>
     </tr>
     <tr>
       <td>Expire User after inactivity</td>
@@ -16,7 +20,11 @@
     </tr>
     <tr>
       <td>User email is permanent</td>
-      <td><input type="checkbox" name="setting[permanent_email]" class="form-control" <% if Setting.permanent_email %>checked <% end %> value="" /></td>
+      <td>
+        <% # The hidden field below allows sending a false value if the checkbox is empty (false) %>
+        <input type="hidden" name="setting[permanent_email]" value="false" />
+        <input type="checkbox" name="setting[permanent_email]" class="form-control" <% if Setting.permanent_email %>checked <% end %> value="true" />
+      </td>
     </tr>
     <tr>
       <td>Reset Password Within</td>

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe Admin::SettingsController, type: :controller do
           Setting.expire_after = nil
         end
 
+        it "doesn't reset permanent email when changing HTML title" do
+          Setting.permanent_email = true
+          post(:update, params: { setting: { html_title_base: 'Custom EyeDP' } })
+          expect(Setting.html_title_base).to eq 'Custom EyeDP'
+          expect(Setting.permanent_email).to be true
+        end
+
+        it "doesn't reset expire_after when changing HTML title" do
+          Setting.expire_after = 30.days
+          post(:update, params: { setting: { html_title_base: 'Custom EyeDP' } })
+          expect(Setting.html_title_base).to eq 'Custom EyeDP'
+          expect(Setting.expire_after).to eq 30.days
+        end
+
         it 'can update expire time' do
           expect(user.expired?).to be false
           post(:update, params: { setting: { expire_after: 30 } })
@@ -93,27 +107,27 @@ RSpec.describe Admin::SettingsController, type: :controller do
           expect(Setting.expire_after).to eq nil
         end
 
-        it 'can enable permenant usernames' do
+        it 'can enable permenant email' do
           Setting.permanent_email = false
-          post(:update, params: { setting: { permanent_email: '' } })
+          post(:update, params: { setting: { permanent_email: 'true' } })
           expect(Setting.permanent_email).to be true
         end
 
-        it 'can disable permenant usernames' do
+        it 'can disable permenant email' do
           Setting.permanent_email = true
-          post(:update, params: { setting: {} })
+          post(:update, params: { setting: { permanent_email: 'false' } })
           expect(Setting.permanent_email).to be false
         end
 
         it 'can enable user registration' do
           Setting.registration_enabled = false
-          post(:update, params: { setting: { registration_enabled: '' } })
+          post(:update, params: { setting: { registration_enabled: 'true' } })
           expect(Setting.registration_enabled).to be true
         end
 
         it 'can disable user registration' do
           Setting.registration_enabled = true
-          post(:update, params: { setting: {} })
+          post(:update, params: { setting: { registration_enabled: 'false' } })
           expect(Setting.registration_enabled).to be false
         end
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Admin::UsersController, type: :controller do
         it 'can add a user to a group' do
           post(:update, params: { id: user.id, user: { group_ids: [admin_group.id, user_group.id] } })
           user.reload
-          expect(user.groups.pluck(:name)).to eq %w[administrators users]
+          expect(user.groups.pluck(:name).sort).to eq %w[administrators users]
         end
 
         it 'can remove a user from a group' do


### PR DESCRIPTION
Previously, several of the options "default" to falsey/nil
when the parameter is not provided for update. This is the
result of a simplistic edit form that did not handle the
falsey/nil value in the actual HTML form, instead defaulting
to falsey/nil when the value was not supplied. This causes
errors after the Settings update pages were split into sections.

Closes #211