### PR TITLE
Change wording on admin/group update page

### DIFF
--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -109,7 +109,7 @@
       <%= render partial: 'custom_datum', locals: { data_type: data_type, custom_datum: custom_groupdatum, disabled: false } %>
     <%- end %>
     <hr />
-    <%= f.submit _('Save Changes'), class: 'btn btn-success' %>
+    <%= f.submit _('Update Additional Properties'), class: 'btn btn-success' %>
   <%- end %>
 </div>
 <%- end %>


### PR DESCRIPTION
The previous wording could leave it unclear which form
was being submitted. This change updates both submit
buttons to more clearly specify what fields are updating.

Closes #214