### PR TITLE
Remove support for Rememberable.

### DIFF
--- a/app/controllers/concerns/authenticates_with_two_factor.rb
+++ b/app/controllers/concerns/authenticates_with_two_factor.rb
@@ -40,12 +40,12 @@ module AuthenticatesWithTwoFactor
     end
   end
 
-  def authenticate_with_two_factor_via_otp(user) # rubocop:disable Metrics/AbcSize
+  def authenticate_with_two_factor_via_otp(user)
     if valid_otp_attempt?(user)
       # Remove any lingering user data from login
       clear_two_factor_attempt!
 
-      remember_me(user) if user_params[:remember_me] == '1'
+      # remember_me(user) if user_params[:remember_me] == '1'
       user.save!
       sign_in(user, message: :two_factor_authenticated, event: :authentication)
     else
@@ -90,7 +90,7 @@ module AuthenticatesWithTwoFactor
     # Remove any lingering user data from login
     clear_two_factor_attempt!
 
-    remember_me(user) if user_params[:remember_me] == '1'
+    # remember_me(user) if user_params[:remember_me] == '1'
     sign_in(user, message: :two_factor_authenticated, event: :authentication)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,8 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :registerable, :recoverable, :rememberable, :validatable,
+  # :rememberable
+  devise :registerable, :recoverable, :validatable,
          :fido_usf_registerable, :timeoutable
 
   devise :expirable

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -97,12 +97,11 @@ RSpec.describe SessionsController do
       context 'remember_me field' do
         it 'sets a remember_user_token cookie when enabled' do
           allow(controller).to receive(:find_user).and_return(user)
-          expect(controller)
-            .to receive(:remember_me).with(user).and_call_original
+          expect(controller).not_to receive(:remember_me)
 
           authenticate_2fa({ remember_me: '1', otp_attempt: user.current_otp })
 
-          expect(response.cookies['remember_user_token']).to be_present
+          expect(response.cookies['remember_user_token']).to be_nil
         end
 
         it 'does nothing when disabled' do
@@ -213,13 +212,11 @@ RSpec.describe SessionsController do
       context 'remember_me field' do
         it 'sets a remember_user_token cookie when enabled' do
           allow(User).to receive(:u2f_authenticate).and_return(true)
-          allow(controller).to receive(:find_user).and_return(user)
-          expect(controller)
-            .to receive(:remember_me).with(user).and_call_original
+          expect(controller).not_to receive(:remember_me)
 
           authenticate_2fa_u2f(remember_me: '1', login: user.username, device_response: '{}')
 
-          expect(response.cookies['remember_user_token']).to be_present
+          expect(response.cookies['remember_user_token']).to be_nil
         end
 
         it 'does nothing when disabled' do


### PR DESCRIPTION
By combining rememberable with timeoutable, a situation is
created where the user should be timed out in 30 inutes of
inactivity; however, a rmember_me cookie being set allows
the user to bypass this restriction.