### PR TITLE
Add a margin attribute when Peek is enabled.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,10 @@ main {
   margin-top: 30px; // accommodate the navbar
 }
 
+body.peek-enabled {
+   margin-bottom: 35px;
+ }
+
 #peek {
   position: fixed;
   bottom: 0;

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -34,5 +34,6 @@
     </main>
     <%= javascript_include_tag 'application' %>
     <%= yield :charts_js %>
+    <%= javascript_tag "$('#peek').parent().addClass('peek-enabled');" %>
   </body>
 </html>


### PR DESCRIPTION
According to https://github.com/peek/peek/pull/64, it is recommended
to use javascript to add a margin to the body attribute when Peek
is enabled.

Closes #226