### PR TITLE
Make session timeouts configurable by an admin.

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -16,12 +16,14 @@ class Admin::SettingsController < AdminController
 
   # PATCH/PUT /admin/settings/1
   # PATCH/PUT /admin/settings/1.json
-  def update # rubocop:disable Metrics/AbcSize
+  def update # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     opts = setting_params
     opts[:expire_after] = opts[:expire_after].to_i.days unless opts[:expire_after].nil?
     opts[:expire_after] = nil if opts[:expire_after].present? && opts[:expire_after] == 0.days
     opts[:devise_reset_password_within] = opts[:devise_reset_password_within].to_i.days \
       if opts[:devise_reset_password_within].present?
+    opts[:session_timeout_in] = opts[:session_timeout_in].to_i.hours unless opts[:session_timeout_in].nil?
+    opts[:session_timeout_in] = nil if opts[:session_timeout_in].present? && opts[:session_timeout_in] == 0.seconds
     opts.each do |setting, value|
       Setting.send("#{setting}=", value)
     end
@@ -40,6 +42,7 @@ class Admin::SettingsController < AdminController
     params.fetch(:setting, {}).permit(
       :idp_base, :html_title_base,
       :devise_reset_password_within,
+      :session_timeout_in,
       :saml_certificate, :saml_key,
       :oidc_signing_key,
       :registration_enabled, :permanent_email,

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -156,6 +156,7 @@ class Setting < ApplicationRecord
   field :logo_height, default: 50, type: :integer
   field :logo_width, default: 100, type: :integer
   field :devise_reset_password_within, type: :time, default: 7.days.iso8601
+  field :session_timeout_in, type: :time, default: 6.hours.iso8601
 
   field :home_template, default: '', type: :string
   field :registered_home_template, default: '', type: :string

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -31,6 +31,13 @@
       <td><input type="text" name="setting[devise_reset_password_within]" class="form-control" value="<%= Setting.devise_reset_password_within.parts[:days] if Setting.devise_reset_password_within %>"/>
         <p class="small">How many days to allow a password reset token to be valid.</p></td>
     </tr>
+    <tr>
+      <td>Session Timeout</td>
+      <td>
+        <input type="text" name="setting[session_timeout]" class="form-control" value="<%= Setting.session_timeout.parts[:hours] if Setting.session_timeout %>"/>
+        <p class="small">How many hours should an inactive session last.</p>
+      </td>
+    </tr>
     <!-- Logo settings -->
   </table>
   <button class="btn btn-primary">Save</button>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -184,6 +184,9 @@ Devise.setup do |config|
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
   # config.timeout_in = 30.minutes
+  def config.timeout_in
+    Setting.session_timeout_in
+  end
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -153,6 +153,22 @@ RSpec.describe Admin::SettingsController, type: :controller do
           expect(Setting.devise_reset_password_within).to eq 30.days
           expect(Devise.reset_password_within).to eq 30.days
         end
+
+        it 'can set the session timeout' do
+          expect(Setting.session_timeout_in).to eq 6.hours
+          expect(Devise.timeout_in).to eq 6.hours
+          post(:update, params: { setting: { session_timeout_in: '24' } })
+          expect(Setting.session_timeout_in).to eq 24.hours
+          expect(Devise.timeout_in).to eq 24.hours
+        end
+
+        it 'can reset the session timeout to default' do
+          Setting.session_timeout_in = 24.hours
+          expect(Devise.timeout_in).to eq 24.hours
+          post(:update, params: { setting: { session_timeout_in: '' } })
+          expect(Setting.session_timeout_in).to eq 6.hours
+          expect(Devise.timeout_in).to eq 6.hours
+        end
       end
     end
 


### PR DESCRIPTION
The default session timeout is also updated in this change
from 30 minutes to 6 hours, in addition to allowing an admin
to customize the time as needed.

Closes #196