### PR TITLE
Expose user.name in user_mailer templates

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -33,6 +33,7 @@ class UserMailer < ApplicationMailer
   def template_variables(user)
     {
       'username' => user.username,
+      'name' => user.name,
       'email' => user.email
     }
   end


### PR DESCRIPTION
Makes `{{name}}` usable in E-Mail templates.