### PR TITLE
An admin can enable and disable :timeoutable

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -156,7 +156,7 @@ class Setting < ApplicationRecord
   field :logo_height, default: 50, type: :integer
   field :logo_width, default: 100, type: :integer
   field :devise_reset_password_within, type: :time, default: 7.days.iso8601
-  field :session_timeout_in, type: :time, default: 6.hours.iso8601
+  field :session_timeout_in, type: :time
 
   field :home_template, default: '', type: :string
   field :registered_home_template, default: '', type: :string

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -35,7 +35,7 @@
       <td>Session Timeout</td>
       <td>
         <input type="text" name="setting[session_timeout_in]" class="form-control" value="<%= Setting.session_timeout_in.parts[:hours] if Setting.session_timeout_in %>"/>
-        <p class="small">How many hours should an inactive session last.</p>
+        <p class="small">How many hours should an inactive session last. Empty disables this feature.</p>
       </td>
     </tr>
     <!-- Logo settings -->

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -155,8 +155,8 @@ RSpec.describe Admin::SettingsController, type: :controller do
         end
 
         it 'can set the session timeout' do
-          expect(Setting.session_timeout_in).to eq 6.hours
-          expect(Devise.timeout_in).to eq 6.hours
+          expect(Setting.session_timeout_in).to be nil
+          expect(Devise.timeout_in).to be nil
           post(:update, params: { setting: { session_timeout_in: '24' } })
           expect(Setting.session_timeout_in).to eq 24.hours
           expect(Devise.timeout_in).to eq 24.hours
@@ -166,8 +166,8 @@ RSpec.describe Admin::SettingsController, type: :controller do
           Setting.session_timeout_in = 24.hours
           expect(Devise.timeout_in).to eq 24.hours
           post(:update, params: { setting: { session_timeout_in: '' } })
-          expect(Setting.session_timeout_in).to eq 6.hours
-          expect(Devise.timeout_in).to eq 6.hours
+          expect(Setting.session_timeout_in).to be nil
+          expect(Devise.timeout_in).to be nil
         end
       end
     end

--- a/spec/controllers/basic_auth_controller_spec.rb
+++ b/spec/controllers/basic_auth_controller_spec.rb
@@ -16,46 +16,83 @@ RSpec.describe BasicAuthController, type: :controller do
     let(:permission) { Permission.create!(name: 'use.test_app') }
     let(:group) { Group.create!(name: 'my_group', permissions: [permission]) }
 
-    it 'allows authenticated role with group' do
-      start = user.last_activity_at
-      @request.env['devise.mapping'] = Devise.mappings[:user]
-      user.groups << group
-      sign_in user
-      get :create, params: { permission_name: 'use.test_app' }
-      expect(response.status).to eq(200)
-      user.reload
-      expect(user.last_activity_at).not_to eq(start)
+    context 'with session timeouts disabled (default)' do
+      before do
+        Setting.session_timeout_in = nil
+      end
+
+      it 'allows authenticated role with group' do
+        start = user.last_activity_at
+        @request.env['devise.mapping'] = Devise.mappings[:user]
+        user.groups << group
+        sign_in user
+        get :create, params: { permission_name: 'use.test_app' }
+        expect(response.status).to eq(200)
+        user.reload
+        expect(user.last_activity_at).not_to eq(start)
+      end
+
+      it 'allows an authenticated, old user session' do
+        start = user.last_activity_at
+        @request.env['devise.mapping'] = Devise.mappings[:user]
+        user.groups << group
+        sign_in user
+        warden.session('user')['last_request_at'] = 7
+        # user.last_acccess = 1.day.ago
+        get :create, params: { permission_name: 'use.test_app' }
+
+        expect(response.status).to eq(200)
+        user.reload
+        expect(user.last_activity_at).not_to eq(start)
+      end
     end
 
-    it 'forbids an authenticated, timed out user' do
-      @request.env['devise.mapping'] = Devise.mappings[:user]
-      user.groups << group
-      sign_in user
-      warden.session('user')['last_request_at'] = 7
-      # user.last_acccess = 1.day.ago
-      get :create, params: { permission_name: 'use.test_app' }
+    context 'with session timeouts enabled' do
+      before do
+        Setting.session_timeout_in = 1.hour
+      end
 
-      expect(response.status).to eq(401)
-    end
+      it 'allows authenticated role with group' do
+        start = user.last_activity_at
+        @request.env['devise.mapping'] = Devise.mappings[:user]
+        user.groups << group
+        sign_in user
+        get :create, params: { permission_name: 'use.test_app' }
+        expect(response.status).to eq(200)
+        user.reload
+        expect(user.last_activity_at).not_to eq(start)
+      end
 
-    it 'it updates last_request_at on use' do
-      @request.env['devise.mapping'] = Devise.mappings[:user]
-      user.groups << group
-      sign_in user
-      start = 5.minutes.ago.to_i
-      warden.session('user')['last_request_at'] = start
-      get :create, params: { permission_name: 'use.test_app' }
-      expect(response.status).to eq(200)
-      expect(warden.session('user')['last_request_at']).not_to eq(start)
-      # Warden is apparently doing something super weird with deciding
-      # to update or not the last_request_at field. The check above passes,
-      # even though it matches this one perfectly. This test is to comfirm
-      # that no regressions are introduced that cause timeouts to happen
-      # while a user regularly hits the auth backend.
-      warden.session('user')['last_request_at'] = start
-      get :create, params: { permission_name: 'use.test_app' }
-      expect(response.status).to eq(200)
-      expect(warden.session('user')['last_request_at']).not_to eq(start)
+      it 'forbids an authenticated, timed out user' do
+        @request.env['devise.mapping'] = Devise.mappings[:user]
+        user.groups << group
+        sign_in user
+        warden.session('user')['last_request_at'] = 7
+        # user.last_acccess = 1.day.ago
+        get :create, params: { permission_name: 'use.test_app' }
+
+        expect(response.status).to eq(401)
+      end
+
+      it 'it updates last_request_at on use' do
+        @request.env['devise.mapping'] = Devise.mappings[:user]
+        user.groups << group
+        sign_in user
+        start = 5.minutes.ago.to_i
+        warden.session('user')['last_request_at'] = start
+        get :create, params: { permission_name: 'use.test_app' }
+        expect(response.status).to eq(200)
+        expect(warden.session('user')['last_request_at']).not_to eq(start)
+        # Warden is apparently doing something super weird with deciding
+        # to update or not the last_request_at field. The check above passes,
+        # even though it matches this one perfectly. This test is to comfirm
+        # that no regressions are introduced that cause timeouts to happen
+        # while a user regularly hits the auth backend.
+        warden.session('user')['last_request_at'] = start
+        get :create, params: { permission_name: 'use.test_app' }
+        expect(response.status).to eq(200)
+        expect(warden.session('user')['last_request_at']).not_to eq(start)
+      end
     end
 
     it 'forbids authenticated role without required two factor' do


### PR DESCRIPTION
When setting the session_timeout_in value to nil, Devise
stops timing out the user. This change also updates the
default setting to disable the feature, but has been tested
to ensure that, if an admin has customised this setting,
their customisation will still be in place.

Closes #237