### PR TITLE
The basic auth controller sends email and username as response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ that may not have their own acess controls at the Nginx layer. To learn more
 about how to use it, an admin should peruse the [groups](#groups) section of
 the documentetion.
 
+In the Nging Auth Request backend, a user's email and username are set as
+response headers: `EyeDP-Email` and `EyeDP-Username`. As a result, Nginx is
+capable of interpreting these headers and send them to other appication
+backends!
+
 ## Management
 
 Managing an identity provider can be a complex task requiring many different

--- a/app/controllers/basic_auth_controller.rb
+++ b/app/controllers/basic_auth_controller.rb
@@ -29,6 +29,8 @@ class BasicAuthController < ApplicationController
                               .uniq
                               .detect { |f| permission_checks.include? f.name }
       if effective_permissions
+        response.set_header('EyeDP-Username', current_user.username)
+        response.set_header('EyeDP-Email', current_user.email)
         head :ok
       else
         head 403

--- a/spec/controllers/basic_auth_controller_spec.rb
+++ b/spec/controllers/basic_auth_controller_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe BasicAuthController, type: :controller do
         Setting.session_timeout_in = nil
       end
 
+      it 'sets username and email as headers' do
+        user.groups << group
+        sign_in user
+        get :create, params: { permission_name: 'use.test_app' }
+        expect(response.status).to eq(200)
+        expect(response.headers['EyeDP-Username']).to eq user.username
+        expect(response.headers['EyeDP-Email']).to eq user.email
+      end
+
       it 'allows authenticated role with group' do
         start = user.last_activity_at
         @request.env['devise.mapping'] = Devise.mappings[:user]


### PR DESCRIPTION
Because this endpoint is intended for use behind an Nginx as
an auth_request, Nginx is the expected consumer of this data.

Closes #253