### PR TITLE
Unify admin/user edit form with custom attributes.

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -6,8 +6,12 @@ class Admin::GroupsController < AdminController
     render :email, layout: nil
   end
 
+  def update
+    update_custom_attributes if params[:custom_data]
+    super
+  end
+
   def update_custom_attributes # rubocop:disable Metrics/MethodLength
-    @model = Group.find(params[:group_id])
     custom_groupdata_params.each do |name, value|
       custom_type = CustomGroupDataType.where(name: name).first
       custom_datum = CustomGroupdatum.where(
@@ -18,10 +22,9 @@ class Admin::GroupsController < AdminController
         custom_datum.value = value
         custom_datum.save
       rescue RuntimeError
-        flash[:error] = 'Failed to update group data, invalid value'
+        flash[:error] << 'Failed to update group data, invalid value'
       end
     end
-    redirect_to [:edit, :admin, @model]
   end
 
   private

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -92,24 +92,19 @@
     <%- end %>
   </div>
 
+  <%- unless new_model %>
+    <div class="col-md-9 col-lg-10">
+      <h2>Additional Properties</h2>
+      <%= link_to "Manage Group Data Types", admin_custom_group_data_types_path, class: 'btn btn-info' %>
+      <%- custom_groupdata = @model.custom_groupdata.includes([:custom_group_data_type]).group_by(&:custom_group_data_type_id) %>
+      <%- CustomGroupDataType.all.each do |data_type| %>
+        <%- custom_groupdatum = custom_groupdata[data_type.id].try(:first) || CustomGroupdatum.new(group: @model, custom_group_data_type: data_type) %>
+        <%= render partial: 'custom_datum', locals: { data_type: data_type, custom_datum: custom_groupdatum, disabled: false } %>
+      <%- end %>
+    </div>
+    <%- end %>
 
   <div class="actions">
     <%= form.submit _('Update Group'), class: 'btn btn-success' %>
   </div>
 <% end %>
-
-<%- unless new_model %>
-<div class="col-md-9 col-lg-10">
-  <h2>Additional Properties</h2>
-  <%= link_to "Manage Group Data Types", admin_custom_group_data_types_path, class: 'btn btn-info' %>
-  <%= form_with(url: admin_group_custom_attributes_path(group_id: @model.id), local: true, class: 'form') do |f| %>
-    <%- custom_groupdata = @model.custom_groupdata.includes([:custom_group_data_type]).group_by(&:custom_group_data_type_id) %>
-    <%- CustomGroupDataType.all.each do |data_type| %>
-      <%- custom_groupdatum = custom_groupdata[data_type.id].try(:first) || CustomGroupdatum.new(group: @model, custom_group_data_type: data_type) %>
-      <%= render partial: 'custom_datum', locals: { data_type: data_type, custom_datum: custom_groupdatum, disabled: false } %>
-    <%- end %>
-    <hr />
-    <%= f.submit _('Update Additional Properties'), class: 'btn btn-success' %>
-  <%- end %>
-</div>
-<%- end %>

--- a/app/views/admin/groups/_show.html.erb
+++ b/app/views/admin/groups/_show.html.erb
@@ -1,16 +1,11 @@
 <div class="col-md-12 col-lg-12">
   <h2>Additional Properties</h2>
-  <%= form_with(url: admin_group_custom_attributes_path(group_id: @model.id), local: true, class: 'form') do |f| %>
-    <%- custom_groupdata = @model.custom_groupdata.includes([:custom_group_data_type]).group_by(&:custom_group_data_type_id) %>
-    <%- CustomGroupDataType.all.each do |data_type| %>
-      <%- custom_groupdatum = custom_groupdata[data_type.id].try(:first) || CustomGroupdatum.new(group: @model, custom_group_data_type: data_type) %>
-      <%= render partial: 'custom_datum', locals: { data_type: data_type, custom_datum: custom_groupdatum, disabled: true } %>
-    <%- end %>
-    <hr />
-    <%= f.submit _('Save Changes'), class: 'btn btn-success' %>
+  <%- custom_groupdata = @model.custom_groupdata.includes([:custom_group_data_type]).group_by(&:custom_group_data_type_id) %>
+  <%- CustomGroupDataType.all.each do |data_type| %>
+    <%- custom_groupdatum = custom_groupdata[data_type.id].try(:first) || CustomGroupdatum.new(group: @model, custom_group_data_type: data_type) %>
+    <%= render partial: 'custom_datum', locals: { data_type: data_type, custom_datum: custom_groupdatum, disabled: true } %>
   <%- end %>
 </div>
-
 
 <h4>Welcome Email Preview</h4>
 <iframe class="col-sm-12" src="<%= @model.id %>/email" sandbox></iframe>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -124,6 +124,18 @@
 
   <%- end %>
 
+  <%- unless new_model %>
+  <div class="col-md-9 col-lg-10">
+    <h2>Additional Properties</h2>
+    <%= link_to "Manage User Data Types", admin_custom_userdata_types_path, class: 'btn btn-info' %>
+      <%- custom_userdata = current_user.custom_userdata.includes([:custom_userdata_type]).group_by(&:custom_userdata_type_id) %>
+      <%- CustomUserdataType.all.each do |data_type| %>
+        <%- custom_userdatum = custom_userdata[data_type.id].try(:first) || CustomUserdatum.new(user: current_user, custom_userdata_type: data_type) %>
+        <%= render partial: 'custom_datum', locals: { data_type: data_type, custom_datum: custom_userdatum, disabled: false } %>
+    <%- end %>
+  </div>
+  <%- end %>
+
   <div class="actions">
     <%- if new_model %>
     <%= form.submit _('Create User'), class: 'btn btn-success' %>
@@ -132,21 +144,6 @@
     <%- end %>
   </div>
 <% end %>
-  <%- unless new_model %>
-  <div class="col-md-9 col-lg-10">
-    <h2>Additional Properties</h2>
-    <%= link_to "Manage User Data Types", admin_custom_userdata_types_path, class: 'btn btn-info' %>
-    <%= form_with(url: admin_user_custom_attributes_path(user_id: @model.id), local: true, class: 'form') do |f| %>
-      <%- custom_userdata = current_user.custom_userdata.includes([:custom_userdata_type]).group_by(&:custom_userdata_type_id) %>
-      <%- CustomUserdataType.all.each do |data_type| %>
-        <%- custom_userdatum = custom_userdata[data_type.id].try(:first) || CustomUserdatum.new(user: current_user, custom_userdata_type: data_type) %>
-        <%= render partial: 'custom_datum', locals: { data_type: data_type, custom_datum: custom_userdatum, disabled: false } %>
-      <%- end %>
-      <hr />
-      <%= f.submit _('Save Changes'), class: 'btn btn-success' %>
-    <%- end %>
-  </div>
-  <%- end %>
 
 <script>
 

--- a/app/views/application/_custom_datum.html.erb
+++ b/app/views/application/_custom_datum.html.erb
@@ -8,12 +8,12 @@
     <div id="<%= custom_datum.name %>">
       <%- if custom_datum.value %>
         <%- custom_datum.value.each do |value| %>
-          <div class="input-group" id="input-group-<%= custom_datum.name %>-<%= value %>">
+          <div class="input-group" id="input-group-<%= custom_datum.name %>-<%= value.gsub('.', '_') %>">
             <%= text_field_tag "custom_data[#{custom_datum.name}][]", value, class: 'form-control', disabled: disabled %>
 
             <%- unless disabled %>
               <div class="input-group-append">
-                <button type="button" class="btn btn-danger" onclick="remove_element(this)" data-target="input-group-<%= custom_datum.name %>-<%= value %>">Remove</button>
+                <button type="button" class="btn btn-danger" onclick="remove_element(this)" data-target="input-group-<%= custom_datum.name %>-<%= value.gsub('.', '_') %>">Remove</button>
               </div>
               <%- end %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,6 @@ Rails.application.routes.draw do
     end
     resources :users do
       post :reset_password, to: 'users#reset_password'
-      post :custom_attributes, to: 'users#update_custom_attributes'
     end
     resources :custom_userdata_types
     resources :custom_group_data_types

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Rails.application.routes.draw do
     # get 'dashboard/index'
     resources :groups do
       get :email, to: 'groups#email'
-      post :custom_attributes, to: 'groups#update_custom_attributes'
     end
     resources :users do
       post :reset_password, to: 'users#reset_password'

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Admin::GroupsController, type: :controller do
         context 'update' do
           it "Can update a group's custom attributes" do
             CustomGroupDataType.create(name: 'alias', custom_type: 'string')
-            post :update_custom_attributes, params: { group_id: group.id, custom_data: { 'alias': 'ahoy' } }
+            post :update, params: { id: group.id, group: { name: group.name }, custom_data: { 'alias': 'ahoy' } }
             data = group.custom_groupdata.first
             expect(data.name).to eq('alias')
             expect(data.value).to eq('ahoy')

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -261,7 +261,11 @@ RSpec.describe Admin::UsersController, type: :controller do
 
         it "Can update a user's custom attributes" do
           CustomUserdataType.create(name: 'Has pets', custom_type: 'boolean')
-          post :update_custom_attributes, params: { user_id: user.id, custom_data: { 'Has pets': true } }
+          post :update, params: {
+            id: user.id,
+            user: { username: user.username },
+            custom_data: { 'Has pets': true }
+          }
           data = user.custom_userdata.first
           expect(data.name).to eq('Has pets')
           expect(data.value).to be true


### PR DESCRIPTION
An admin should not have to identify which is the correct submit
button to update user fields vs custom attributes.

Closes #256