### PR TITLE
Update audit log display for index and several specific types.

### DIFF
--- a/app/controllers/admin/audits_controller.rb
+++ b/app/controllers/admin/audits_controller.rb
@@ -8,7 +8,7 @@ class Admin::AuditsController < AdminController
   end
 
   def whitelist_attributes
-    %w[auditable_type audited_changes]
+    %w[auditable_type action audited_changes]
   end
 
   def ensure_user_is_authorized!

--- a/app/views/admin/audits/_source_user.html.erb
+++ b/app/views/admin/audits/_source_user.html.erb
@@ -1,7 +1,11 @@
 <h5>User who performed change</h5>
-<dl>
-  <dt>Username</dt>
-  <dd><%= @model.user.username %></dd>
-  <dt>Email</dt>
-  <dd><%= @model.user.email %></dd>
-</dl>
+<%- if @model.user %>
+	<dl>
+	  <dt>Username</dt>
+	  <dd><%= @model.user.username %></dd>
+	  <dt>Email</dt>
+	  <dd><%= @model.user.email %></dd>
+	</dl>
+<%- else %>
+  None
+<%- end %>

--- a/app/views/admin/audits/index.html.erb
+++ b/app/views/admin/audits/index.html.erb
@@ -44,7 +44,11 @@
             <%- if data.is_a? ActiveRecord::Associations::CollectionProxy %>
               <%- data =  data.join ", " %>
             <%- end %>
-            <%= data %>
+            <%- if attr_name == 'audited_changes' %>
+                <pre><code><%= data.to_yaml %></code></pre>
+            <%- else %>
+              <%= data %>
+              <%- end %>
           </td>
         <%- end %>
       </tr>

--- a/app/views/admin/audits/show.html.erb
+++ b/app/views/admin/audits/show.html.erb
@@ -1,7 +1,7 @@
 <h2>Audit</h2>
 <%= render partial: 'sub_heading' %>
 <div class="row">
-  <%= link_to 'Back', [:admin, 'audits'] %>
+  <%= link_to 'Back', [:admin, :audits] %>
 </div>
 
 <div class="row">
@@ -10,7 +10,20 @@
         <%= render partial: @model.auditable_type.underscore.gsub('/', '_') %>
     <% rescue ActionView::MissingTemplate %>
       <h4>
-        <%= @model.action %> - <%= link_to "#{@model.auditable_type} '#{@model.auditable}'", [:admin, @model.auditable] %>
+        <%= @model.action %> - 
+        <%- if @model.auditable_type == "CustomUserdatum" %>
+          <%= link_to "#{@model.auditable_type} 'Custom Userdata' for User '#{@model.auditable.user}'", [:admin, 
+            @model.auditable.user] %>
+
+        <%- elsif @model.auditable_type == 'CustomGroupdatum' %>
+          <%= link_to "#{@model.auditable_type} 'Custom Data' for Group '#{@model.auditable.group}'", [:admin, 
+            @model.auditable.group] %>
+        <%- elsif @model.auditable_type == 'GroupPermission' %>
+          <%= link_to "#{@model.auditable_type} 'Group Permission' for Group '#{@model.auditable.group}'", [:admin, 
+            @model.auditable.group] %>
+        <%- else %>
+          <%= link_to "#{@model.auditable_type} '#{@model.auditable}'", [:admin, @model.auditable] %>
+          <%- end %>
       </h4>
       <%=  @model.created_at.to_formatted_s(:rfc822) %>
       <hr />


### PR DESCRIPTION
When displaying audit logs, YAML is a more readable default
representation that allows an admin easier overview. This
change additionally resolves some errors in rendering the
show pages for specific models that do not have individual
admin pages (eg: custom userdata).

Closes #236