### PR TITLE
Move from Peek to Rack::MiniProfiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,10 +64,13 @@ gem 'scout_apm'
 # gem 'ledermann-rails-settings'
 # gem 'rails-settings-cached'
 
-gem 'peek'
-gem 'peek-gc'
-gem 'peek-performance_bar'
-gem 'peek-pg'
+# profiling
+gem 'rack-mini-profiler'
+# For memory profiling
+gem 'memory_profiler'
+# For call-stack profiling flamegraphs
+gem 'stackprof'
+
 gem 'tipsy-rails'
 
 # SAML the things!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,8 +137,6 @@ GEM
     chunky_png (1.4.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
-    concurrent-ruby-ext (1.1.9)
-      concurrent-ruby (= 1.1.9)
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
@@ -247,6 +245,7 @@ GEM
       sqlite3-ruby
       thin
     marcel (1.0.1)
+    memory_profiler (1.0.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -277,17 +276,6 @@ GEM
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    peek (1.1.0)
-      railties (>= 4.0.0)
-    peek-gc (0.0.2)
-      peek
-    peek-performance_bar (1.3.1)
-      peek (>= 0.1.0)
-    peek-pg (1.3.0)
-      concurrent-ruby
-      concurrent-ruby-ext
-      peek
-      pg
     pg (1.2.3)
     popper_js (1.16.0)
     pry (0.13.1)
@@ -303,6 +291,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-mini-profiler (2.3.3)
+      rack (>= 1.2.0)
     rack-protection (2.1.0)
       rack
     rack-test (1.1.0)
@@ -461,6 +451,7 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stackprof (0.2.17)
     temple (0.8.2)
     text (1.3.1)
     thin (1.8.1)
@@ -546,16 +537,14 @@ DEPENDENCIES
   liquid
   listen (>= 3.0.5)
   mailcatcher
+  memory_profiler
   nokogiri (>= 1.11.0.rc4)
   overcommit
-  peek
-  peek-gc
-  peek-performance_bar
-  peek-pg
   pg (~> 1.1)
   pry-byebug
   pry-rails
   puma (~> 4.3)
+  rack-mini-profiler
   rails (~> 6.0)
   rails-erd
   rails-i18n
@@ -574,6 +563,7 @@ DEPENDENCIES
   simplecov-lcov
   spring
   spring-watcher-listen (~> 2.0.0)
+  stackprof
   timecop
   tipsy-rails
   translation

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,7 +18,5 @@
 //= require chartkick
 //= require Chart.bundle
 //= require u2f-api
-//= require peek
-//= require peek/views/performance_bar
 //= require tipsy
 //= require profile

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,12 +7,6 @@
 @import "font-awesome";
 @import "rails_bootstrap_forms";
 
-
-//= require peek
-//= require peek/views/performance_bar
-
-@import "peek";
-@import "peek/views/performance_bar";
 @import "tipsy";
 // apply styles to HTML elements
 // to make views framework-neutral

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -41,6 +41,7 @@ class Admin::SettingsController < AdminController
   def setting_params # rubocop:disable Metrics/MethodLength
     params.fetch(:setting, {}).permit(
       :idp_base, :html_title_base,
+      :profiler_enabled,
       :devise_reset_password_within,
       :session_timeout_in,
       :saml_certificate, :saml_key,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   after_action :set_useragent_and_ip_in_session
   before_action :set_locale
+  before_action :authorize_rack_mini_profiler
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
@@ -27,8 +28,8 @@ class ApplicationController < ActionController::Base
     request.env['omniauth.origin'] || redirect || stored_location_for(resource) || root_url
   end
 
-  def peek_enabled?
-    super || current_user&.admin?
+  def authorize_rack_mini_profiler
+    Rack::MiniProfiler.authorize_request if current_user&.admin? && Setting.profiler_enabled
   end
 
   # U2F (universal 2nd factor) devices need a unique identifier for the application

--- a/app/controllers/basic_auth_controller.rb
+++ b/app/controllers/basic_auth_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BasicAuthController < ApplicationController
+  skip_before_action :authorize_rack_mini_profiler
+
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -173,4 +173,6 @@ class Setting < ApplicationRecord
   field :html_title_base, default: 'EyeDP', type: :string
 
   field :webhook_timeout, default: 60, type: :integer
+
+  field :profiler_enabled, default: false, type: :boolean
 end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -38,7 +38,14 @@
         <p class="small">How many hours should an inactive session last. Empty disables this feature.</p>
       </td>
     </tr>
-    <!-- Logo settings -->
+    <tr>
+      <td>Enable Profiler for Admins</td>
+      <td>
+        <% # The hidden field below allows sending a false value if the checkbox is empty (false) %>
+        <input type="hidden" name="setting[profiler_enabled]" value="false" />
+        <input type="checkbox" name="setting[profiler_enabled]" class="form-control" <% if Setting.profiler_enabled %>checked <% end %> value="true" />
+      </td>
+    </tr>
   </table>
   <button class="btn btn-primary">Save</button>
 <%- end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -17,7 +17,6 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
   </head>
   <body>
-    <%= render 'peek/bar' %>
     <header>
       <%= render 'layouts/navigation' %>
     </header>
@@ -35,6 +34,5 @@
     </main>
     <%= javascript_include_tag 'application' %>
     <%= yield :charts_js %>
-    <%= javascript_tag "$('#peek').parent().addClass('peek-enabled');" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,6 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
   </head>
   <body>
-    <%= render 'peek/bar' if peek_enabled? %>
     <header>
       <%= render 'layouts/navigation' %>
     </header>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,4 +17,4 @@ Rails.application.config.assets.precompile += %w[*.png *.jpg *.jpeg *.gif]
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[admin.js admin.css]

--- a/config/initializers/peek.rb
+++ b/config/initializers/peek.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Peek.into Peek::Views::PerformanceBar
-Peek.into Peek::Views::PG
-Peek.into Peek::Views::GC

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+url = ENV['REDIS_URL'] || 'redis://localhost:6379'
+
+if url
+  Rack::MiniProfiler.config.storage_options = { url: url }
+  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
     controllers authorizations: 'oauth_applications'
   end
   use_doorkeeper_openid_connect
-  mount Peek::Railtie => '/peek'
   get 'admin' => 'admin/dashboard#index', as: :admin_dashboard
   namespace :admin do
     # get 'dashboard/index'

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe Admin::SettingsController, type: :controller do
           expect(Setting.registration_enabled).to be false
         end
 
+        it 'can enable profiling' do
+          Setting.profiler_enabled = false
+          post(:update, params: { setting: { profiler_enabled: 'true' } })
+          expect(Setting.profiler_enabled).to be true
+        end
+
+        it 'can disable profiling' do
+          Setting.profiler_enabled = true
+          post(:update, params: { setting: { profiler_enabled: 'false' } })
+          expect(Setting.profiler_enabled).to be false
+        end
+
         it 'can set password reset template' do
           post(:update, params: { setting: { admin_reset_email_template: 'Password was reset!' } })
           expect(Setting.admin_reset_email_template).to eq 'Password was reset!'


### PR DESCRIPTION
Peek has not been updated in a few years so this
change moves EyeDP to using a supported profiling
gem.

Closes #292
Closes #231