### PR TITLE
An admin can create a user without sending a welcome email

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,13 +2,19 @@
 
 class Admin::UsersController < AdminController # rubocop:disable Metrics/ClassLength
   def show
+    @reset_token = session[:reset_token]
+    session[:reset_token] = nil
     super
     @logins = @model.logins.includes(:service_provider).order(created_at: :desc).limit(50)
   end
 
   def create
     super
-    @model.send_admin_welcome_email if @model.persisted?
+    if params[:send_welcome_email]
+      @model.send_admin_welcome_email
+    else
+      session[:reset_token] = @model.send(:set_reset_password_token)
+    end
   end
 
   def update

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -136,6 +136,19 @@
   </div>
   <%- end %>
 
+  <%- if new_model %>
+    <div class="form-group">
+      <div class="row">
+        <div class="col-sm-2">
+          <%= label_tag :send_welcome_email %>
+        </div>
+        <div class="col-sm-10">
+            <%= check_box_tag :send_welcome_email, true, true %>
+        </div>
+      </div>
+    </div>
+  <%- end %>
+
   <div class="actions">
     <%- if new_model %>
     <%= form.submit _('Create User'), class: 'btn btn-success' %>

--- a/app/views/admin/users/_sub_heading.html.erb
+++ b/app/views/admin/users/_sub_heading.html.erb
@@ -1,7 +1,7 @@
 <%- if @model.expired? %>
   <div class="alert alert-warning" role="alert">
-      <%= content_tag :div, "This user is expired" %>
-    </div>
+    <%= content_tag :div, "This user is expired" %>
+  </div>
 <%- end %>
 <div class="col-sm-12">
   <%= form_with(model: [:admin, @model], local: true, class: 'form-inline') do |form| %>
@@ -10,3 +10,12 @@
     <%= render partial: 'toggle_user', locals: { model: @model, form: form } %>
   <%- end %>
 </div>
+<%- if @reset_token %>
+  <%- url = edit_password_url(@model, reset_password_token: @reset_token) %>
+  <div class="alert alert-info" role="alert">
+    <%= content_tag :div do %>
+      <p>This link will only be shown once!</p>
+      <p>Password reset link: <%= url %></p>
+    <%- end %>
+  </div>
+<%- end %>

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -82,9 +82,21 @@ RSpec.describe Admin::UsersController, type: :controller do
 
       it 'can create a user' do
         expect(User.where(email: 'testing@localhost').count).to eq 0
-        post(:create, params: { user: { email: 'testing@localhost', username: 'testing-name' } })
+        post(:create,
+             params: { send_welcome_email: true, user: { email: 'testing@localhost', username: 'testing-name' } })
         expect(response.status).to eq(302)
         expect(User.where(email: 'testing@localhost').count).to eq 1
+      end
+
+      it 'can create a user and retrieve reset link' do
+        expect do
+          perform_enqueued_jobs do
+            expect(User.where(email: 'testing@localhost').count).to eq 0
+            post(:create, params: { user: { email: 'testing@localhost', username: 'testing-name' } })
+            expect(response.status).to eq(302)
+            expect(User.where(email: 'testing@localhost').count).to eq 1
+          end
+        end.to change { ActionMailer::Base.deliveries.count }.by(0)
       end
 
       it 'can update a user' do
@@ -187,10 +199,21 @@ RSpec.describe Admin::UsersController, type: :controller do
         it 'can create a user' do
           expect do
             perform_enqueued_jobs do
-              post(:create, params: { user: { email: 'test@example.com', username: 'test' } })
+              post(:create, params: { send_welcome_email: true, user: { email: 'test@example.com', username: 'test' } })
               expect(response.status).to eq(302)
             end
           end.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
+
+        it 'can create a user and retrieve reset link' do
+          expect do
+            perform_enqueued_jobs do
+              expect(User.where(email: 'testing@localhost').count).to eq 0
+              post(:create, params: { user: { email: 'testing@localhost', username: 'testing-name' } })
+              expect(response.status).to eq(302)
+              expect(User.where(email: 'testing@localhost').count).to eq 1
+            end
+          end.to change { ActionMailer::Base.deliveries.count }.by(0)
         end
       end
 


### PR DESCRIPTION
When an admin toggles sending an email to false, a password
reset link will be provided, once, to the creating user on
the redirect target page.

Closes #289