### PR TITLE
It supports bearer tokens for the basic auth handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,12 @@ response headers: `EyeDP-Email` and `EyeDP-Username`. As a result, Nginx is
 capable of interpreting these headers and send them to other appication
 backends!
 
+In addition to supporting general user sessions, it is possible to grant a user
+access to personal access tokens via the permit_token attribute on a group that
+they are a member of. When they have this permission, setting the header
+`EyeDP-Authorize` to their access_token will allow passing through the basic
+auth controller without a user session.
+
 ## Management
 
 Managing an identity provider can be a complex task requiring many different

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -30,15 +30,15 @@ class Admin::GroupsController < AdminController
   private
 
   def whitelist_attributes
-    %w[name parent requires_2fa roles permissions]
+    %w[name parent requires_2fa permit_token roles permissions]
   end
 
   def new_fields
-    %w[name description requires_2fa]
+    %w[name description permit_token requires_2fa]
   end
 
   def show_whitelist_attributes
-    %w[name description parent requires_2fa roles permissions]
+    %w[name description parent requires_2fa permit_token roles permissions]
   end
 
   def form_relations
@@ -64,7 +64,7 @@ class Admin::GroupsController < AdminController
   def model_params # rubocop:disable Metrics/MethodLength
     permitted_params = [
       :name, :description, :parent, :welcome_email, :requires_2fa,
-      { permission_ids: [] }
+      :permit_token, { permission_ids: [] }
     ]
     if current_user.admin?
       permitted_params << :admin

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -159,7 +159,7 @@ class Admin::UsersController < AdminController # rubocop:disable Metrics/ClassLe
   private
 
   def includes
-    %i[groups emails]
+    %i[groups emails access_tokens]
   end
 
   def show_whitelist_attributes

--- a/app/controllers/profile/access_tokens_controller.rb
+++ b/app/controllers/profile/access_tokens_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Profile::AccessTokensController < ApplicationController
+  before_action :authenticate_user!
+  before_action :verify_user_permission!
+
+  def index
+    @token = AccessToken.new(user: current_user)
+    @tokens = current_user.access_tokens
+    return unless session[:new_token]
+
+    @new_token = AccessToken.find(session[:new_token])
+    session.delete(:new_token)
+  end
+
+  def create # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    @token = AccessToken.new(token_params)
+    respond_to do |format|
+      if @token.save
+        session[:new_token] = @token.id
+        format.html { redirect_to profile_access_tokens_path, notice: 'Token was successfully created.' }
+        format.json { render :index, status: :created, location: @token }
+      else
+        format.html { render :index }
+        format.json { render json: @token.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /profile/access_tokens/#{model}/1
+  # DELETE /profile/access_tokens/#{model}/1.json
+  def destroy
+    @token = AccessToken.find(params[:id])
+    redirect_to :back, notice: "You don't have permission to delete this access token" if @token.user != current_user
+    @token.destroy
+    respond_to do |format|
+      format.html { redirect_to profile_access_tokens_path, notice: 'Token was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  protected
+
+  def token_params
+    p = params.require(:access_token).permit(:name, :expires_at)
+    p[:user_id] = current_user.id
+    p
+  end
+
+  def verify_user_permission!
+    current_user.groups.where(permit_token: true).any?
+  end
+end

--- a/app/controllers/profile/emails_controller.rb
+++ b/app/controllers/profile/emails_controller.rb
@@ -14,7 +14,7 @@ class Profile::EmailsController < ApplicationController
       if @email.save
         @email.send_confirmation_instructions
         format.html { redirect_to profile_emails_path, notice: 'Email was successfully created.' }
-        format.json { render :index, status: :created, location: [:admin, @email] }
+        format.json { render :index, status: :created, location: @email }
       else
         format.html { render :index }
         format.json { render json: @email.errors, status: :unprocessable_entity }

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -6,7 +6,7 @@ class ProfileController < ApplicationController
   before_action :set_flash_on_restrictions
 
   def show # rubocop:disable Metrics/MethodLength
-    @template = Liquid::Template.parse(Setting.registered_home_template)
+    @template = Liquid::Template.parse(Setting.registered_home_template) if Setting.registered_home_template.present?
     @logins = current_user
               .logins
               .includes([:service_provider])

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AccessToken < ApplicationRecord
+  belongs_to :user
+
+  after_initialize :setup_token
+
+  def setup_token
+    self.token ||= SecureRandom.hex(32)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   audited
 
   has_many :emails, dependent: :destroy
+  has_many :access_tokens, dependent: :destroy
 
   alias_attribute :real_name, :name
 
@@ -55,12 +56,12 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :group_permissions, through: :groups
   has_many :permissions, through: :group_permissions
 
-  has_many :access_grants,
+  has_many :oatch_access_grants,
            class_name: 'Doorkeeper::AccessGrant',
            foreign_key: :resource_owner_id,
            dependent: :delete_all # or :destroy if you need callbacks
 
-  has_many :access_tokens,
+  has_many :oauth_access_tokens,
            class_name: 'Doorkeeper::AccessToken',
            foreign_key: :resource_owner_id,
            dependent: :delete_all # or :destroy if you need callbacks

--- a/app/views/admin/users/_show.html.erb
+++ b/app/views/admin/users/_show.html.erb
@@ -56,6 +56,32 @@
 </div>
 
 <div class="col-md-9 col-lg-10">
+  <h2>Access Tokens</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Created</th>
+        <th>Last Used</th>
+        <th>Expires At</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%- @model.access_tokens.each do |token| %>
+        <tr>
+          <td><%= token.name %></td>
+          <td><%= token.created_at %></td>
+          <td><%= token.last_used_at %></td>
+          <td><%= token.expires_at %></td>
+          <td><%= link_to 'Revoke', profile_access_tokens_path(token), method: :delete, data: { confirm: 'Are you sure you want to revoke this token?' }, class: 'btn btn-danger' %></td>
+        </tr>
+      <%- end %>
+    </tbody>
+  </table>
+</div>
+
+<div class="col-md-9 col-lg-10">
   <h2>Custom Properties</h2>
   <%- custom_userdata = @model.custom_userdata.includes([:custom_userdata_type]).group_by(&:custom_userdata_type_id) %>
   <%- CustomUserdataType.all.each do |data_type| %>

--- a/app/views/profile/_profile_nav.html.erb
+++ b/app/views/profile/_profile_nav.html.erb
@@ -5,6 +5,9 @@
     <%= nav_link _("Profile"), profile_path %>
     <%- end %>
     <%= nav_link _("Emails"), profile_emails_path %>
+    <%- if current_user.groups.where(permit_token: true).any? %>
+    <%= nav_link _("Access Tokens"), profile_access_tokens_path %>
+    <%- end %>
     <%= nav_link _("Authentication devices"), profile_authentication_devices_path %>
     <%= nav_link _("Account activity"), profile_account_activity_path %>
   </ul>

--- a/app/views/profile/access_tokens/index.html.erb
+++ b/app/views/profile/access_tokens/index.html.erb
@@ -1,0 +1,73 @@
+<h1 class="flex justify-center">Welcome, <%= current_user.username || current_user.email %></h1>
+<hr />
+<div class="row">
+  <%= render partial: 'profile/profile_nav' %>
+  <div class="col-md-9 col-lg-10">
+    <h2>Personal Access Tokens</h2>
+    <%- if @new_token %>
+    <div class="row">
+
+      <div class="col-12">
+        <h4>Your new personal access token</h4>
+        <%= text_field_tag '', @new_token.token, disabled: true, class: 'form-control' %>
+        <p class="small">Make sure you save it - you won't be able to access it again.</p>
+      </div>
+    </div>
+    <%- end %>
+    <div class="row">
+      <div class="col-12">
+        <h4>Add a personal access token </h4>
+
+        <%= bootstrap_form_for @token, url: profile_access_tokens_path do |f| %>
+          <% if @token.errors.any? %>
+            <div id="error_explanation">
+              <h2><%= pluralize(@token.errors.count, "error") %> prohibited this access token from being saved:</h2>
+
+              <ul>
+              <% @token.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+              </ul>
+            </div>
+          <% end %>
+          <div class="input-group">
+            <%= f.text_field :name %>
+          </div>
+          <div class="input-group">
+            <%= f.date_field :expires_at %>
+          </div>
+          <%= f.submit _('Save Changes'), class: 'btn btn-success', style: "float: left" %>
+        <% end %>
+      </div>
+    </div>
+    <hr />
+    <div class="row">
+      <div class="col-12">
+        <h4> Active personal access tokens (<%= @tokens.count %>) </h4>
+
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Created</th>
+                <th>Last Used</th>
+                <th>Expires At</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <%- @tokens.each do |token| %>
+                <tr>
+                  <td><%= token.name %></td>
+                  <td><%= token.created_at %></td>
+                  <td><%= token.last_used_at %></td>
+                  <td><%= token.expires_at %></td>
+                  <td><%= link_to 'Revoke', [:profile, token], method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to revoke this personal access token? This action cannot be undone.' } %></td>
+                </tr>
+              <%- end %>
+            </tbody>
+            </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,5 +99,6 @@ Rails.application.routes.draw do
     resources :emails do
       post 'resend_confirmation', to: 'emails#resend_confirmation', as: :resend_confirmation
     end
+    resources :access_tokens
   end
 end

--- a/db/migrate/20211113065546_add_permit_token_to_group.rb
+++ b/db/migrate/20211113065546_add_permit_token_to_group.rb
@@ -1,0 +1,5 @@
+class AddPermitTokenToGroup < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groups, :permit_token, :boolean, default: false
+  end
+end

--- a/db/migrate/20211113065909_create_access_tokens.rb
+++ b/db/migrate/20211113065909_create_access_tokens.rb
@@ -1,0 +1,13 @@
+class CreateAccessTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :access_tokens, id: :uuid do |t|
+      t.text :token, null: false
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.text :name
+      t.date :expires_at
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_07_071320) do
+ActiveRecord::Schema.define(version: 2021_11_13_065909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "access_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "token", null: false
+    t.uuid "user_id", null: false
+    t.text "name"
+    t.date "expires_at"
+    t.datetime "last_used_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_access_tokens_on_user_id"
+  end
 
   create_table "api_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "key", null: false
@@ -168,6 +179,7 @@ ActiveRecord::Schema.define(version: 2021_11_07_071320) do
     t.boolean "admin", default: false
     t.boolean "manager", default: false
     t.boolean "operator", default: false
+    t.boolean "permit_token", default: false
     t.index ["parent_id"], name: "index_groups_on_parent_id"
   end
 
@@ -329,6 +341,7 @@ ActiveRecord::Schema.define(version: 2021_11_07_071320) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "access_tokens", "users"
   add_foreign_key "custom_groupdata", "custom_group_data_types"
   add_foreign_key "custom_groupdata", "groups"
   add_foreign_key "custom_userdata", "custom_userdata_types"

--- a/spec/requests/saml_flow_spec.rb
+++ b/spec/requests/saml_flow_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'SAML Flow', type: :request do
         saml_response = OneLogin::RubySaml::Response.new Base64.decode64(match[1])
         saml_attrs = saml_response.attributes.to_h
         expect(saml_attrs).to match(user_attributes)
-        expect(saml_attrs['groups']).to match([users_group.name, group.name])
+        expect(saml_attrs['groups']).to match_array([users_group.name, group.name])
       end
     end
   end


### PR DESCRIPTION
Access to management and use of access tokens is restricted to
users of groups that have this feature enabled. When a valid
access token is provided, a 200 is returned from the Nginx
auth request handler, even without an existing user session.
This can be used to allow enabled users to communicate with
APIs behind the Nginx auth request.

Closes #183