### PR TITLE
Password minimum length can be configured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'rails-i18n'
 gem 'devise'
 gem 'devise_fido_usf'
 gem 'devise-i18n'
-gem 'devise-multi_email', github: 'indietools/devise-multi_email'
+gem 'devise-multi_email', github: 'centaurisolutions/devise-multi_email'
 gem 'friendly_id'
 # Do TOTP 2FA
 gem 'devise-two-factor', github: 'centaurisolutions/devise-two-factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/centaurisolutions/devise-multi_email.git
+  revision: 5e29a72fc777327981b6fc2b7534a6148e456b8c
+  specs:
+    devise-multi_email (3.0.0)
+      devise
+
+GIT
   remote: https://github.com/centaurisolutions/devise-two-factor.git
   revision: cf43ea1367fb30c738de416be59616a76098c226
   specs:
@@ -8,13 +15,6 @@ GIT
       devise (~> 4.0)
       railties (< 6.2)
       rotp (~> 6.0)
-
-GIT
-  remote: https://github.com/indietools/devise-multi_email.git
-  revision: b73f118e77ca70119410eb447a7cd8451298c4d0
-  specs:
-    devise-multi_email (3.0.0)
-      devise
 
 GEM
   remote: https://rubygems.org/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   devise :registerable, # :recoverable,
          :fido_usf_registerable, :timeoutable
 
-  devise :multi_email_authenticatable,
+  devise :multi_email_authenticatable, :multi_email_validatable,
          :multi_email_recoverable, :multi_email_confirmable
 
   devise :expirable

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -175,7 +175,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = (ENV['MIN_PASSWORD_LENGTH'] || 10)..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,8 +27,8 @@ if user.persisted?
 end
 
 user.username = ENV['SEED_USERNAME'].presence || 'admin'
-user.password = ENV['SEED_PASSWORD'].presence || 'password'
+user.password = ENV['SEED_PASSWORD'].presence || 'password123'
 puts "Creating user '#{user.username}' with password: '#{user.password}'"
-user.password_confirmation = ENV['SEED_PASSWORD'].presence || 'password'
+user.password_confirmation = ENV['SEED_PASSWORD'].presence || 'password123'
 user.groups << groups[:administrators]
 user.save!

--- a/spec/controllers/admin/applications_controller_spec.rb
+++ b/spec/controllers/admin/applications_controller_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Admin::ApplicationsController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'user', email: 'user@localhost', password: 'test1234')
+    user = User.create!(username: 'user', email: 'user@localhost', password: 'test123456')
     user.confirm!
     user
   end
   let(:group) { Group.create!(name: 'administrators', admin: true) }
   let(:admin) do
-    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test1234')
+    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test123456')
     user.groups << group
     user.confirm!
     user
@@ -25,7 +25,7 @@ RSpec.describe Admin::ApplicationsController, type: :controller do
     context 'signed in manager' do
       let(:manager_group) { Group.create!(name: 'managers', manager: true) }
       let(:manager) do
-        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test123456')
         user.groups << manager_group
         user.confirm!
         user
@@ -43,7 +43,7 @@ RSpec.describe Admin::ApplicationsController, type: :controller do
     context 'signed in operator' do
       let(:operator_group) { Group.create!(name: 'operators', operator: true) }
       let(:operator) do
-        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test123456')
         user.groups << operator_group
         user.confirm!
         user

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Admin::DashboardController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'user', email: 'user@localhost', password: 'test1234')
+    user = User.create!(username: 'user', email: 'user@localhost', password: 'test123456')
     user.confirm!
     user
   end
   let(:group) { Group.create!(name: 'administrators', admin: true) }
   let(:admin) do
-    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test1234')
+    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test123456')
     user.groups << group
     user.confirm!
     user
@@ -20,7 +20,7 @@ RSpec.describe Admin::DashboardController, type: :controller do
     context 'signed in manager' do
       let(:manager_group) { Group.create!(name: 'managers', manager: true) }
       let(:manager) do
-        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test123456')
         user.groups << manager_group
         user.confirm!
         user
@@ -55,7 +55,7 @@ RSpec.describe Admin::DashboardController, type: :controller do
     context 'signed in operator' do
       let(:operator_group) { Group.create!(name: 'operators', operator: true) }
       let(:operator) do
-        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test123456')
         user.groups << operator_group
         user.confirm!
         user

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::GroupsController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'user', email: 'user@localhost', password: 'test1234')
+    user = User.create!(username: 'user', email: 'user@localhost', password: 'test123456')
     user.confirm!
     user
   end
@@ -12,7 +12,7 @@ RSpec.describe Admin::GroupsController, type: :controller do
   let(:users_group) { Group.create!(name: 'usesr') }
   let(:permission) { Permission.create!(name: 'test permission') }
   let(:admin) do
-    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test1234')
+    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test123456')
     user.groups << group
     user.confirm!
     user
@@ -22,7 +22,7 @@ RSpec.describe Admin::GroupsController, type: :controller do
     context 'signed in manager' do
       let(:manager_group) { Group.create!(name: 'managers', manager: true) }
       let(:manager) do
-        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test123456')
         user.groups << manager_group
         user.confirm!
         user
@@ -64,7 +64,7 @@ RSpec.describe Admin::GroupsController, type: :controller do
     context 'signed in operator' do
       let(:operator_group) { Group.create!(name: 'operators', operator: true) }
       let(:operator) do
-        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test123456')
         user.groups << operator_group
         user.confirm!
         user

--- a/spec/controllers/admin/saml_service_providers_controller_spec.rb
+++ b/spec/controllers/admin/saml_service_providers_controller_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Admin::SamlServiceProvidersController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'user', email: 'user@localhost', password: 'test1234')
+    user = User.create!(username: 'user', email: 'user@localhost', password: 'test123456')
     user.confirm!
     user
   end
   let(:group) { Group.create!(name: 'administrators', admin: true) }
   let(:admin) do
-    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test1234')
+    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test123456')
     user.groups << group
     user.confirm!
     user
@@ -26,7 +26,7 @@ RSpec.describe Admin::SamlServiceProvidersController, type: :controller do
     context 'signed in manager' do
       let(:manager_group) { Group.create!(name: 'managers', manager: true) }
       let(:manager) do
-        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test123456')
         user.groups << manager_group
         user.confirm!
         user
@@ -44,7 +44,7 @@ RSpec.describe Admin::SamlServiceProvidersController, type: :controller do
     context 'signed in operator' do
       let(:operator_group) { Group.create!(name: 'operators', operator: true) }
       let(:operator) do
-        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test123456')
         user.groups << operator_group
         user.confirm!
         user

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Admin::SettingsController, type: :controller do
   let(:user) do
     user = User.create!(
       username: 'user', email: 'user@localhost',
-      password: 'test1234', last_activity_at: 1.year.ago
+      password: 'test123456', last_activity_at: 1.year.ago
     )
     user.confirm!
     user
   end
   let(:group) { Group.create!(name: 'administrators', admin: true) }
   let(:admin) do
-    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test1234')
+    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test123456')
     user.groups << group
     user.confirm!
     user
@@ -23,7 +23,7 @@ RSpec.describe Admin::SettingsController, type: :controller do
     context 'signed in manager' do
       let(:manager_group) { Group.create!(name: 'managers', manager: true) }
       let(:manager) do
-        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+        user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test123456')
         user.groups << manager_group
         user.confirm!
         user
@@ -41,7 +41,7 @@ RSpec.describe Admin::SettingsController, type: :controller do
     context 'signed in operator' do
       let(:operator_group) { Group.create!(name: 'operators', operator: true) }
       let(:operator) do
-        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+        user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test123456')
         user.groups << operator_group
         user.confirm!
         user

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::UsersController, type: :controller do
   include ActiveJob::TestHelper
   let(:user) do
-    user = User.new(username: 'user', email: 'user@localhost', password: 'test1234')
+    user = User.new(username: 'user', email: 'user@localhost', password: 'test123456')
     user.emails[0].confirmed_at = Time.now.utc
     user.save!
     user
@@ -13,7 +13,7 @@ RSpec.describe Admin::UsersController, type: :controller do
   let(:admin_group) { Group.create!(name: 'administrators', admin: true) }
   let(:user_group) { Group.create!(name: 'users') }
   let(:admin) do
-    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test1234')
+    user = User.create!(username: 'admin', email: 'admin@localhost', password: 'test123456')
     user.groups << admin_group
     user.confirm!
     user
@@ -21,7 +21,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   let(:operator_group) { Group.create!(name: 'operators', operator: true) }
   let(:operator) do
-    user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test1234')
+    user = User.create!(username: 'operator', email: 'operator@localhost', password: 'test123456')
     user.groups << operator_group
     user.confirm!
     user
@@ -29,7 +29,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   let(:manager_group) { Group.create!(name: 'managers', manager: true) }
   let(:manager) do
-    user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test1234')
+    user = User.create!(username: 'manager', email: 'manager@localhost', password: 'test123456')
     user.groups << manager_group
     user.confirm!
     user
@@ -510,19 +510,19 @@ RSpec.describe Admin::UsersController, type: :controller do
         end
 
         it 'can reset a user passowrd' do
-          expect(user.valid_password?('test1234')).to be true
+          expect(user.valid_password?('test123456')).to be true
           post(:reset_password, params: { user_id: user.id })
           expect(response.status).to eq(302)
           user.reload
-          expect(user.valid_password?('test1234')).to be false
+          expect(user.valid_password?('test123456')).to be false
         end
 
         it 'can set a user password' do
-          expect(user.valid_password?('test1234')).to be true
+          expect(user.valid_password?('test123456')).to be true
           post(:update, params: { id: user.id, user: { password: 'testing-it' } })
           expect(response.status).to eq(302)
           user.reload
-          expect(user.valid_password?('test1234')).to be false
+          expect(user.valid_password?('test123456')).to be false
           expect(user.valid_password?('testing-it')).to be true
         end
 

--- a/spec/controllers/api/groups_controller_spec.rb
+++ b/spec/controllers/api/groups_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::GroupsController, type: :controller do
   let(:group) { Group.create!(name: 'group') }
   let(:user) do
-    u = User.create!(username: 'user', email: 'user@localhost', password: 'test1234')
+    u = User.create!(username: 'user', email: 'user@localhost', password: 'test123456')
     u.groups << group
     u
   end
@@ -68,7 +68,7 @@ RSpec.describe Api::GroupsController, type: :controller do
 
       it 'can not add a user to the group' do
         expect(group.users).to eq [user]
-        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test1234')
+        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test123456')
         post(:add_user, params: { group_id: group.id, user_id: user2.id })
         expect(response.status).to eq(400)
         group.reload
@@ -133,7 +133,7 @@ RSpec.describe Api::GroupsController, type: :controller do
 
       it 'can not add a user to the group' do
         expect(group.users).to eq [user]
-        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test1234')
+        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test123456')
         post(:add_user, params: { api_key: 'nope', group_id: group.id, user_id: user2.id })
         expect(response.status).to eq(403)
         group.reload
@@ -198,7 +198,7 @@ RSpec.describe Api::GroupsController, type: :controller do
 
       it 'can not add a user to the group' do
         expect(group.users).to eq [user]
-        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test1234')
+        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test123456')
         post(:add_user, params: { api_key: api_key.key, group_id: group.id, user_id: user2.id })
         expect(response.status).to eq(403)
         group.reload
@@ -282,7 +282,7 @@ RSpec.describe Api::GroupsController, type: :controller do
 
       it 'can add a user to the group' do
         expect(group.users).to eq [user]
-        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test1234')
+        user2 = User.create!(username: 'user2', email: 'user2@localhost', password: 'test123456')
         post(:add_user, params: { api_key: api_key.key, group_id: group.id, user_id: user2.id })
         group.reload
         expect(group.users).to match [user, user2]

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::UsersController, type: :controller do
-  let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+  let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test123456') }
 
   let(:empty_key) { ApiKey.create }
 

--- a/spec/controllers/basic_auth_controller_spec.rb
+++ b/spec/controllers/basic_auth_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe BasicAuthController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end

--- a/spec/controllers/oauth_applications_controller_spec.rb
+++ b/spec/controllers/oauth_applications_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe OauthApplicationsController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end

--- a/spec/controllers/profile/account_activity_spec.rb
+++ b/spec/controllers/profile/account_activity_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Profile::AccountActivityController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end

--- a/spec/controllers/profile/authentication_devices_spec.rb
+++ b/spec/controllers/profile/authentication_devices_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Profile::AuthenticationDevicesController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end

--- a/spec/controllers/profile/profile_spec.rb
+++ b/spec/controllers/profile/profile_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Profile::ProfileController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ProfileController, type: :controller do
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe RegistrationsController, type: :controller do
   include DeviseHelpers
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end
@@ -21,14 +21,14 @@ RSpec.describe RegistrationsController, type: :controller do
     end
 
     it 'can edit name' do
-      patch(:update, params: { id: user.id, user: { name: 'test', current_password: 'test1234' } })
+      patch(:update, params: { id: user.id, user: { name: 'test', current_password: 'test123456' } })
       expect(response.status).to eq(302)
       user.reload
       expect(user.name).to eq('test')
     end
 
     it 'cannot edit email' do
-      patch(:update, params: { id: user.id, user: { email: 'test2@localhost', current_password: 'test1234' } })
+      patch(:update, params: { id: user.id, user: { email: 'test2@localhost', current_password: 'test123456' } })
       expect(response.status).to eq(302)
       user.reload
       expect(user.email).to eq('test@localhost')
@@ -41,14 +41,14 @@ RSpec.describe RegistrationsController, type: :controller do
     end
 
     it 'can edit name' do
-      patch(:update, params: { id: user.id, user: { name: 'test', current_password: 'test1234' } })
+      patch(:update, params: { id: user.id, user: { name: 'test', current_password: 'test123456' } })
       expect(response.status).to eq(302)
       user.reload
       expect(user.name).to eq('test')
     end
 
     it 'can edit email' do
-      patch(:update, params: { id: user.id, user: { email: 'test2@localhost', current_password: 'test1234' } })
+      patch(:update, params: { id: user.id, user: { email: 'test2@localhost', current_password: 'test123456' } })
       expect(response.status).to eq(302)
       user.reload
       expect(user.email).to eq('test2@localhost')

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SessionsController do
 
       context 'when using valid password' do
         let(:user) do
-          user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+          user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
           user.confirm!
           user
         end
@@ -84,27 +84,27 @@ RSpec.describe SessionsController do
 
         context 'with multiple emails' do
           let(:user) do
-            user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+            user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
             user.confirm!
             Email.create!(address: 'test2@localhost', user: user).confirm
             user
           end
 
           it 'allows login with the primary email' do
-            post(:create, params: { user: { login: user.email, password: 'test1234' } })
+            post(:create, params: { user: { login: user.email, password: 'test123456' } })
 
             expect(subject.current_user).to eq user
           end
 
           it 'allows login with additional emails' do
             user
-            post(:create, params: { user: { login: 'test2@localhost', password: 'test1234' } })
+            post(:create, params: { user: { login: 'test2@localhost', password: 'test123456' } })
             expect(subject.current_user).to eq user
           end
 
           it 'requires additional emails to be confirmed for login' do
             Email.create!(address: 'test3@localhost', user: user)
-            post(:create, params: { user: { login: 'test3@localhost', password: 'test1234' } })
+            post(:create, params: { user: { login: 'test3@localhost', password: 'test123456' } })
             expect(subject.current_user).to be_nil
             expect(controller)
               .to set_flash.now[:alert].to(/Invalid Login or password/)
@@ -115,7 +115,7 @@ RSpec.describe SessionsController do
 
     context 'when using two-factor authentication via OTP' do
       let(:user) do
-        user = User.new(username: 'example', email: 'test@localhost', password: 'test1234')
+        user = User.new(username: 'example', email: 'test@localhost', password: 'test123456')
         user.otp_required_for_login = true
         user.otp_secret = User.generate_otp_secret(32)
         user.generate_otp_backup_codes!
@@ -175,7 +175,7 @@ RSpec.describe SessionsController do
       context 'when authenticating with login and OTP of another user' do
         context 'when another user has 2FA enabled' do
           let(:another_user) do
-            user = User.new(username: 'example2', email: 'test2@localhost', password: 'test1234')
+            user = User.new(username: 'example2', email: 'test2@localhost', password: 'test123456')
             user.otp_required_for_login = true
             user.otp_secret = User.generate_otp_secret(32)
             user.generate_otp_backup_codes!
@@ -232,7 +232,7 @@ RSpec.describe SessionsController do
 
     context 'when using two-factor authentication via U2F device' do
       let(:user) do
-        user = User.new(username: 'example', email: 'test@localhost', password: 'test1234')
+        user = User.new(username: 'example', email: 'test@localhost', password: 'test123456')
         user.otp_required_for_login = true
         user.otp_secret = User.generate_otp_secret(32)
         user.generate_otp_backup_codes!

--- a/spec/controllers/sudo_rails/application_controller_spec.rb
+++ b/spec/controllers/sudo_rails/application_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SudoRails::ApplicationController, type: :controller do
       sign_in(user)
     end
     let(:user) do
-      user = User.new(username: 'example', email: 'test@localhost', password: 'test1234')
+      user = User.new(username: 'example', email: 'test@localhost', password: 'test123456')
       user.otp_required_for_login = true
       user.otp_secret = User.generate_otp_secret(32)
       user.generate_otp_backup_codes!

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
   context 'group_welcome_email' do
-    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test123456') }
     let(:group) { Group.create!(name: 'administrators', admin: true) }
 
     let(:mail) { UserMailer.group_welcome_email(user, group, 'user@localhost') }
@@ -22,7 +22,7 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   context 'force_reset_password_email' do
-    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test123456') }
     let(:mail) { UserMailer.force_reset_password_email(user, 'test token', 'user@localhost') }
 
     it 'renders the headers' do
@@ -42,7 +42,7 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   context 'admin_welcome_email' do
-    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test1234') }
+    let(:user) { User.create!(username: 'user', email: 'user@localhost', password: 'test123456') }
     let(:mail) { UserMailer.admin_welcome_email(user, 'test token', 'user@localhost') }
 
     it 'renders the headers' do

--- a/spec/models/custom_userdata_spec.rb
+++ b/spec/models/custom_userdata_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe CustomUserdatum, type: :model do
   let(:custom_bool) { CustomUserdataType.create(name: 'has_pets', custom_type: 'boolean') }
-  let(:user) { User.create!(username: 'example', email: 'test@localhost', password: 'test1234') }
+  let(:user) { User.create!(username: 'example', email: 'test@localhost', password: 'test123456') }
 
   it { should be_audited }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe User, type: :model do
   include ActiveJob::TestHelper
 
   let(:user) do
-    u = User.new(username: 'example', email: 'test@localhost', password: 'test1234')
+    u = User.new(username: 'example', email: 'test@localhost', password: 'test123456')
     u.emails[0].confirmed_at = Time.now.utc
     u.save!
     u
@@ -109,9 +109,9 @@ RSpec.describe User, type: :model do
 
   it 'only changes password when encrypted_password is nil' do
     user.password = nil
-    expect(user.valid_password?('test1234')).to be true
+    expect(user.valid_password?('test123456')).to be true
     user.save
-    expect(user.valid_password?('test1234')).to be true
+    expect(user.valid_password?('test123456')).to be true
     old_encrypted = user.encrypted_password
     user.encrypted_password = nil
     user.save
@@ -207,7 +207,7 @@ RSpec.describe User, type: :model do
     it 'queues a webhook on create' do
       create_webhook
       expect do
-        User.create!(email: 'test@example.com', username: 'test_user', password: 'test1234')
+        User.create!(email: 'test@example.com', username: 'test_user', password: 'test123456')
       end.to change(NotificationSetupWorker.jobs, :size).by(1)
     end
 

--- a/spec/requests/openid_connect_flow_spec.rb
+++ b/spec/requests/openid_connect_flow_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'OpenID Connect Flow', type: :request do
     Setting.oidc_signing_key = nil
   end
   let(:user) do
-    user = User.create!(username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end

--- a/spec/requests/saml_flow_spec.rb
+++ b/spec/requests/saml_flow_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'SAML Flow', type: :request do
   let(:user) do
-    user = User.create!(name: 'example name', username: 'example', email: 'test@localhost', password: 'test1234')
+    user = User.create!(name: 'example name', username: 'example', email: 'test@localhost', password: 'test123456')
     user.confirm!
     user
   end


### PR DESCRIPTION
The default minimum length for a password is 10 but can be
customised via the environment variable MIN_PASSWORD_LENGTH.

Closes #342