### PR TITLE
Password is a valid custom userdata type.

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -15,7 +15,6 @@ class Admin::DashboardController < AdminController
                     .where('created_at > ?', 7.days.ago).count
       logins = logins.map do |deets, count|
         app = deets[0].constantize.find(deets[1])
-        app = Application.find(app.id) if app.is_a? Doorkeeper::Application
         [app, count]
       end
       logins.sort_by { |login| - login[1] }.take(10)

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -9,7 +9,7 @@ class Admin::DashboardController < AdminController
 
   private
 
-  def logins_by_app # rubocop:disable Metrics/AbcSize
+  def logins_by_app
     @logins_by_app ||= begin
       logins = Login.group(%i[service_provider_type service_provider_id])
                     .where('created_at > ?', 7.days.ago).count

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -84,7 +84,7 @@ class Admin::GroupsController < AdminController
   end
 
   def custom_groupdata_params
-    params.require(:custom_data).permit!
+    params.require(:custom_data).permit(CustomGroupDataType.permit!)
   end
 
   def ensure_user_is_authorized!

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -190,7 +190,7 @@ class Admin::UsersController < AdminController # rubocop:disable Metrics/ClassLe
   end
 
   def custom_userdata_params
-    params.require(:custom_data).permit!
+    params.require(:custom_data).permit(CustomUserdataType.permit!)
   end
 
   def ensure_user_is_authorized!

--- a/app/controllers/profile/profile_controller.rb
+++ b/app/controllers/profile/profile_controller.rb
@@ -14,6 +14,7 @@ class Profile::ProfileController < ApplicationController
       ).first_or_initialize
       next if custom_datum.read_only
 
+      value.reject!(&:empty?) if value.is_a? Array
       begin
         if value.present?
           custom_datum.value = value

--- a/app/controllers/profile/profile_controller.rb
+++ b/app/controllers/profile/profile_controller.rb
@@ -21,12 +21,12 @@ class Profile::ProfileController < ApplicationController
         flash[:error] = 'Failed to update userdata, invalid value'
       end
     end
-    redirect_to profile_additional_properties_path
+    redirect_to profile_path
   end
 
   protected
 
   def custom_userdata_params
-    params.require(:custom_data).permit!
+    params.require(:custom_data).permit(CustomUserdataType.permit!)
   end
 end

--- a/app/controllers/profile/profile_controller.rb
+++ b/app/controllers/profile/profile_controller.rb
@@ -5,7 +5,7 @@ class Profile::ProfileController < ApplicationController
 
   def index; end
 
-  def update # rubocop:disable Metrics/MethodLength
+  def update # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     custom_userdata_params.each do |name, value|
       custom_type = CustomUserdataType.where(name: name).first
       custom_datum = CustomUserdatum.where(
@@ -15,8 +15,12 @@ class Profile::ProfileController < ApplicationController
       next if custom_datum.read_only
 
       begin
-        custom_datum.value = value
-        custom_datum.save
+        if value.present?
+          custom_datum.value = value
+          custom_datum.save
+        else
+          custom_datum.destroy
+        end
       rescue RuntimeError
         flash[:error] = 'Failed to update userdata, invalid value'
       end

--- a/app/models/concerns/deserializable.rb
+++ b/app/models/concerns/deserializable.rb
@@ -4,16 +4,22 @@ module Deserializable
   SEPARATOR_REGEXP = /[\n,;]+/.freeze
 
   # takes a string and returns a typed thing
-  def deserialize(value, custom_type) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+  def deserialize(value, custom_type) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     case custom_type
     when 'boolean'
+      return nil unless ['t', 'true', '1', 1, true, :true, 'f', 'false', '0', 0, false, :false].include? value #  rubocop:disable Lint/BooleanSymbol
+
       ['t', 'true', '1', 1, true, :true].include?(value) #  rubocop:disable Lint/BooleanSymbol
     when 'array'
       return value if value.is_a?(Array)
 
-      (value || '').split(SEPARATOR_REGEXP).map(&:strip).reject(&:empty?)
+      (value || '').split(SEPARATOR_REGEXP).map(&:strip).reject(&:empty?) || nil
     when 'integer'
-      value.to_i
+      begin
+        value.to_i
+      rescue NomethodError
+        nil
+      end
     else
       value
     end

--- a/app/models/concerns/deserializable.rb
+++ b/app/models/concerns/deserializable.rb
@@ -31,7 +31,7 @@ module Deserializable
                 is_array
               when 'integer'
                 new_value.is_a?(Integer)
-              when 'string'
+              when 'string', 'password'
                 raise "Invalid Data: #{new_value} isn't a string" unless new_value.is_a? String
 
                 true
@@ -40,6 +40,7 @@ module Deserializable
               end
       raise "Invalid #{type_s}: #{new_value} isn't an #{type}" unless valid
     end
+    new_value = User.new(password: new_value).encrypted_password if type == 'password' && new_value != value_raw
     self.value_raw = new_value
   end
 end

--- a/app/models/custom_group_data_type.rb
+++ b/app/models/custom_group_data_type.rb
@@ -4,4 +4,14 @@ class CustomGroupDataType < ApplicationRecord
   audited
 
   has_many :custom_groupdata, dependent: :destroy
+
+  def self.permit!
+    CustomGroupDataType.pluck(:name, :custom_type).map do |name, kind|
+      if kind == 'array'
+        { name.to_sym => [] }
+      else
+        name.to_sym
+      end
+    end
+  end
 end

--- a/app/models/custom_userdata_type.rb
+++ b/app/models/custom_userdata_type.rb
@@ -4,4 +4,14 @@ class CustomUserdataType < ApplicationRecord
   audited
 
   has_many :custom_userdata, dependent: :destroy
+
+  def self.permit!
+    CustomUserdataType.pluck(:name, :custom_type).map do |name, kind|
+      if kind == 'array'
+        { name.to_sym => [] }
+      else
+        name.to_sym
+      end
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -216,7 +216,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # end
 
   def roles
-    asserted_groups.map(&:roles).flatten.uniq
+    @roles ||= asserted_groups.map(&:roles).flatten.uniq
   end
 
   def login

--- a/app/views/admin/custom_userdata_types/_form.html.erb
+++ b/app/views/admin/custom_userdata_types/_form.html.erb
@@ -28,7 +28,7 @@
           <%= form.label :custom_type %>
         </div>
         <div class="col-sm-10">
-            <%= form.select :custom_type, [[:boolean, :boolean], [:string, :string], [:array, :array]], class: 'form-control' %>
+            <%= form.select :custom_type, [[:boolean, :boolean], [:string, :string], [:array, :array], [:password, :password]], class: 'form-control' %>
         </div>
       </div>
     </div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -79,7 +79,11 @@
       <table class="table">
       <%- logins_by_app.each do |app, count| %>
         <tr>
-          <td><%= link_to app.name, [:admin, app] %></td>
+          <%- if app.is_a? Doorkeeper::Application %>
+            <td><%= link_to app.name, admin_application_path(app) %></td>
+          <%- else %>
+            <td><%= link_to app.name, [:admin, app] %></td>
+          <%- end %>
           <td><%= count %></td>
         </tr>
       <%- end %>
@@ -115,12 +119,12 @@
         <%- @logins.each do |login| %>
         <tr>
           <%- sp = login.service_provider %>
-          <% if sp.kind_of? Doorkeeper::Application %>
-            <%- sp = Application.find(sp.id) %>
-          <%- end %>
           <% name = sp.try(:name) || sp.to_s %>
-          <% url = sp.display_url || sp.to_s %>
-          <td><%= link_to name, url %></td>
+          <%- if sp.is_a? Doorkeeper::Application %>
+            <td><%= link_to sp.name, admin_application_path(sp) %></td>
+          <%- else %>
+            <td><%= link_to sp.name, [:admin, sp] %></td>
+          <%- end %>
           <td><%= link_to login.user.username, [:admin, login.user] %></td>
           <td><%= login.auth_type %></td>
           <td><%= login.created_at.to_formatted_s(:long) %></td>

--- a/app/views/application/_custom_datum.html.erb
+++ b/app/views/application/_custom_datum.html.erb
@@ -28,6 +28,8 @@
     <%- end %>
   <%- when 'integer' %>
     <%= number_field_tag "custom_data[#{custom_datum.name}]", custom_datum.value, class: 'form-control', disabled: disabled %>
+  <%- when 'password' %>
+    <%= password_field_tag "custom_data[#{custom_datum.name}]", custom_datum.value, class: 'form-control', disabled: disabled %>
   <%- else %>
     <%= text_field_tag "custom_data[#{custom_datum.name}]", custom_datum.value, class: 'form-control', disabled: disabled %>
   <%- end %>

--- a/app/views/profile/profile/index.html.erb
+++ b/app/views/profile/profile/index.html.erb
@@ -4,7 +4,7 @@
   <%= render partial: 'profile/profile_nav' %>
   <div class="col-md-9 col-lg-10">
     <h2>Profile</h2>
-    <%= bootstrap_form_for(current_user, as: 'user', url: profile_additional_properties_path, html: { method: :post }) do |f| %>
+    <%= bootstrap_form_for(current_user, as: 'user', url: profile_path, html: { method: :post }) do |f| %>
       <%- custom_userdata = current_user.custom_userdata.includes([:custom_userdata_type]).group_by(&:custom_userdata_type_id) %>
       <%- CustomUserdataType.all.each do |data_type| %>
         <%- custom_userdatum = custom_userdata[data_type.id].try(:first) || CustomUserdatum.new(user: current_user, custom_userdata_type: data_type) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,26 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
-      "fingerprint": "13849a8caacc51cec8cbf8f62daa69ad94413135de49ae500cb52d8eee91a963",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/profile/profile_controller.rb",
-      "line": 30,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:custom_data).permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Profile::ProfileController",
-        "method": "custom_userdata_params"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": "This uses additional checks elsewhere to restrict the assignment."
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "1b5e4ee151da24cae32d3e2dbb5b9e47ea332d0e903546eb7b3a811c4a0af130",
@@ -154,46 +134,6 @@
       "note": "Setting.registered_home_template is only configurable by an admin."
     },
     {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
-      "fingerprint": "d620a3a379b4a94f3a8002091aef9f0527f2528a77da432685b22c17843a1430",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/admin/groups_controller.rb",
-      "line": 87,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:custom_data).permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Admin::GroupsController",
-        "method": "custom_groupdata_params"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": "This is an admin only controller, and is restricted by a whitelist of acceptable options"
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
-      "fingerprint": "db893cc6b6b379ddeff2ffed97d2ad8c33afb1d9ba6f351c354efe668545b0b6",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/admin/users_controller.rb",
-      "line": 221,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:custom_data).permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Admin::UsersController",
-        "method": "custom_userdata_params"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": "This is an admin only controller, and is restricted by a whitelist of acceptable options"
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "ded083a60327240307d2f69b0215746d34ab49f4580f611080a7f584647c1b6a",
@@ -214,6 +154,6 @@
       "note": "This is an admin only controller, and is restricted by a whitelist of acceptable options"
     }
   ],
-  "updated": "2021-11-12 08:26:01 +0100",
+  "updated": "2021-11-24 08:41:23 +0100",
   "brakeman_version": "5.1.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,11 +95,9 @@ Rails.application.routes.draw do
   get 'profile/account', to: 'profile#show'
   namespace :profile do
     get '/', to: 'profile#index', as: :profile
-    post '/', to: 'profile#update'
+    match '/', to: 'profile#update', via: %i[patch post]
     get 'authentication_devices', to: 'authentication_devices#index'
     get 'account_activity', to: 'account_activity#index'
-    get 'additional_properties', to: 'additional_properties#index'
-    post 'additional_properties', to: 'additional_properties#update'
     resources :emails do
       post 'resend_confirmation', to: 'emails#resend_confirmation', as: :resend_confirmation
     end

--- a/spec/controllers/profile/profile_spec.rb
+++ b/spec/controllers/profile/profile_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Profile::ProfileController, type: :controller do
   end
   let(:custom_bool) { CustomUserdataType.create(name: 'Has pets', custom_type: 'boolean') }
   let(:custom_string) { CustomUserdataType.create(name: 'Nickname', custom_type: 'string') }
+  let(:custom_array) { CustomUserdataType.create(name: 'Nicknames', custom_type: 'array') }
   let(:custom_password) { CustomUserdataType.create(name: 'Demo password', custom_type: 'password') }
 
   before do
@@ -37,6 +38,23 @@ RSpec.describe Profile::ProfileController, type: :controller do
         data = user.custom_userdata.first
         expect(data.name).to eq('Has pets')
         expect(data.value).to be true
+      end
+
+      it 'ignores invalid custom attributes' do
+        post :update, params: { custom_data: { 'Has pets': 'indeed' } }
+        expect(user.custom_userdata.count).to eq(0)
+        expect(flash[:error]).to match('Failed to update userdata, invalid value')
+      end
+
+      it 'deleted custom attributes' do
+        CustomUserdatum.where(
+          user_id: user.id,
+          custom_userdata_type: custom_bool,
+          value_raw: true
+        ).first_or_create
+        expect(user.custom_userdata.count).to eq(1)
+        post :update, params: { custom_data: { 'Has pets': nil } }
+        expect(user.custom_userdata.count).to eq(0)
       end
 
       it 'cannot update read-only attributes' do
@@ -71,6 +89,17 @@ RSpec.describe Profile::ProfileController, type: :controller do
         expect(data.value).to eq('new nick')
       end
 
+      it 'deleted custom attributes' do
+        CustomUserdatum.where(
+          user_id: user.id,
+          custom_userdata_type: custom_string,
+          value_raw: 'thingy'
+        ).first_or_create
+        expect(user.custom_userdata.count).to eq(1)
+        post :update, params: { custom_data: { 'Nickname': nil } }
+        expect(user.custom_userdata.count).to eq(0)
+      end
+
       it 'cannot update read-only attributes' do
         custom_string.update(user_read_only: true)
         custom_datum = CustomUserdatum.where(
@@ -91,6 +120,30 @@ RSpec.describe Profile::ProfileController, type: :controller do
       end
     end
 
+    context 'array type' do
+      before do
+        custom_array
+      end
+
+      it 'updates custom attributes' do
+        post :update, params: { custom_data: { 'Nicknames': %w[nick1 nick2] } }
+        data = user.custom_userdata.first
+        expect(data.name).to eq('Nicknames')
+        expect(data.value).to eq(%w[nick1 nick2])
+      end
+
+      it 'deleted custom attributes' do
+        CustomUserdatum.where(
+          user_id: user.id,
+          custom_userdata_type: custom_array,
+          value_raw: 'thingy'
+        ).first_or_create
+        expect(user.custom_userdata.count).to eq(1)
+        post :update, params: { custom_data: { 'Nicknames': [nil], 'ignored': true } }
+        expect(user.custom_userdata.count).to eq(0)
+      end
+    end
+
     context 'password type' do
       before do
         custom_password
@@ -102,6 +155,17 @@ RSpec.describe Profile::ProfileController, type: :controller do
         expect(data.name).to eq('Demo password')
 
         expect(User.new(encrypted_password: data.value).valid_password?('new password')).to be true
+      end
+
+      it 'deleted custom attributes' do
+        CustomUserdatum.where(
+          user_id: user.id,
+          custom_userdata_type: custom_password,
+          value_raw: 'thingy'
+        ).first_or_create
+        expect(user.custom_userdata.count).to eq(1)
+        post :update, params: { custom_data: { 'Demo password': nil } }
+        expect(user.custom_userdata.count).to eq(0)
       end
 
       it 'cannot update read-only attributes' do

--- a/spec/controllers/profile/profile_spec.rb
+++ b/spec/controllers/profile/profile_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Profile::ProfileController, type: :controller do
     user
   end
   let(:custom_bool) { CustomUserdataType.create(name: 'Has pets', custom_type: 'boolean') }
+  let(:custom_string) { CustomUserdataType.create(name: 'Nickname', custom_type: 'string') }
 
   before do
     sign_in(user)
@@ -25,31 +26,68 @@ RSpec.describe Profile::ProfileController, type: :controller do
   end
 
   context 'update' do
-    it 'updates custom attributes' do
-      custom_bool
-      post :update, params: { custom_data: { 'Has pets': true } }
-      data = user.custom_userdata.first
-      expect(data.name).to eq('Has pets')
-      expect(data.value).to be true
+    context 'boolean type' do
+      before do
+        custom_bool
+      end
+
+      it 'updates custom attributes' do
+        post :update, params: { custom_data: { 'Has pets': true } }
+        data = user.custom_userdata.first
+        expect(data.name).to eq('Has pets')
+        expect(data.value).to be true
+      end
+
+      it 'cannot update read-only attributes' do
+        custom_bool.update(user_read_only: true)
+        custom_datum = CustomUserdatum.where(
+          user_id: user.id,
+          custom_userdata_type: custom_bool
+        ).first_or_initialize
+        custom_datum.value = false
+        custom_datum.save
+        post :update, params: { custom_data: { 'Has pets': true } }
+        data = user.custom_userdata.first
+        expect(data.name).to eq('Has pets')
+        expect(data.value).to be false
+        custom_bool.update(user_read_only: false)
+        post :update, params: { custom_data: { 'Has pets': true } }
+        data = user.custom_userdata.first
+        expect(data.name).to eq('Has pets')
+        expect(data.value).to be true
+      end
     end
 
-    it 'cannot update read-only attributes' do
-      custom_bool.update(user_read_only: true)
-      custom_datum = CustomUserdatum.where(
-        user_id: user.id,
-        custom_userdata_type: custom_bool
-      ).first_or_initialize
-      custom_datum.value = false
-      custom_datum.save
-      post :update, params: { custom_data: { 'Has pets': true } }
-      data = user.custom_userdata.first
-      expect(data.name).to eq('Has pets')
-      expect(data.value).to be false
-      custom_bool.update(user_read_only: false)
-      post :update, params: { custom_data: { 'Has pets': true } }
-      data = user.custom_userdata.first
-      expect(data.name).to eq('Has pets')
-      expect(data.value).to be true
+    context 'string type' do
+      before do
+        custom_string
+      end
+
+      it 'updates custom attributes' do
+        post :update, params: { custom_data: { 'Nickname': 'new nick' } }
+        data = user.custom_userdata.first
+        expect(data.name).to eq('Nickname')
+        expect(data.value).to eq('new nick')
+      end
+
+      it 'cannot update read-only attributes' do
+        custom_string.update(user_read_only: true)
+        custom_datum = CustomUserdatum.where(
+          user_id: user.id,
+          custom_userdata_type: custom_string
+        ).first_or_initialize
+        custom_datum.value = 'locked nick'
+        custom_datum.save
+        post :update, params: { custom_data: { 'Nickname': 'new nick' } }
+        data = user.custom_userdata.first
+        expect(data.name).to eq('Nickname')
+        expect(data.value).to eq('locked nick')
+        custom_string.update(user_read_only: false)
+        post :update, params: { custom_data: { 'Nickname': 'new nick' } }
+        data = user.custom_userdata.first
+        expect(data.name).to eq('Nickname')
+        expect(data.value).to eq('new nick')
+      end
     end
   end
 end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProfileController, type: :controller do
     )
   end
 
-  context 'User dashboard' do
+  context 'User account' do
     render_views
     before do
       sign_in(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,33 +46,39 @@ RSpec.describe User, type: :model do
   it 'makes a user Admin is it has membership' do
     expect(user.admin?).to be false
     user.groups << group
-    expect(user.admin?).to be true
+    this_user = User.find(user.id)
+    expect(this_user.admin?).to be true
   end
 
   it 'makes a user Operator if it has membership' do
     expect(user.operator?).to be false
     user.groups << operator_group
-    expect(user.operator?).to be true
+    this_user = User.find(user.id)
+    expect(this_user.operator?).to be true
   end
 
   it 'makes the user Manager if it has membership' do
     expect(user.manager?).to be false
     user.groups << manager_group
-    expect(user.manager?).to be true
+    this_user = User.find(user.id)
+    expect(this_user.manager?).to be true
   end
 
   it 'does not grant admin just because of a group name' do
     group.admin = false
     user.groups << group
-    expect(user.admin?).to be false
+    this_user = User.find(user.id)
+    expect(this_user.admin?).to be false
   end
 
   it 'can require an admin to have 2fa before adding' do
     group.update({ requires_2fa: true })
     user.groups << group
-    expect(user.admin?).to be false
-    user.update({ otp_required_for_login: true })
-    expect(user.admin?).to be true
+    this_user = User.find(user.id)
+    expect(this_user.admin?).to be false
+    this_user = User.find(user.id)
+    this_user.update({ otp_required_for_login: true })
+    expect(this_user.admin?).to be true
   end
 
   it 'does not make a non-admin an admin' do


### PR DESCRIPTION
When using the password custom data type, the value will
be hashed using the same method as regular user password
hashing before storing it in the database. This maintains
alignment with integrations that may want to shift from
using the password for a user to app specific passwords.

Additionally, this reduces the necessity for brakeman ignores
by adding explicit validation for custom data types.

Closes #291