### PR TITLE
Resolve a pair of session fixation bugs around multi-factor auth

### DIFF
--- a/app/controllers/concerns/authenticates_with_two_factor.rb
+++ b/app/controllers/concerns/authenticates_with_two_factor.rb
@@ -36,6 +36,7 @@ module AuthenticatesWithTwoFactor
     elsif user_params[:device_response].present? && session[:otp_user_id]
       authenticate_with_two_factor_via_u2f(user)
     elsif user&.valid_password?(user_params[:password])
+      reset_session
       prompt_for_two_factor(user)
     end
   end
@@ -98,6 +99,7 @@ module AuthenticatesWithTwoFactor
     session.delete(:otp_user_id)
     session.delete(:user_password_hash)
     session.delete(:challenge)
+    reset_session
   end
 
   def handle_changed_user(_user)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
-RSpec.describe SessionsController do
+RSpec.describe SessionsController, type: :controller do
   include DeviseHelpers
 
   before do
@@ -154,6 +154,12 @@ RSpec.describe SessionsController do
 
           expect(response.cookies['remember_user_token']).to be_nil
         end
+      end
+
+      it 'has a strict timeout on OTP attempts' do
+        post(:create, params: { user: { remember_me: '0', otp_attempt: user.current_otp } },
+session: { otp_user_id: user.id, otp_started: (Time.now.utc - 10.minutes).to_s })
+        expect(flash.now[:alert]).to eq('It took too long to verify your authentication device. Please try again')
       end
 
       it 'redirects to a known application' do


### PR DESCRIPTION
Sessions should be reset between authentication levels, and a user should have a limit on how long to input their multi-factor authentication.