### PR TITLE
Fix several incorrect use of current_user.groups

### DIFF
--- a/app/controllers/basic_auth_controller.rb
+++ b/app/controllers/basic_auth_controller.rb
@@ -10,7 +10,7 @@ class BasicAuthController < ApplicationController
   def create
     key = request.headers['EyeDP-Authorize']
     token = AccessToken.where(token: key).where('expires_at > NOW() or expires_at IS NULL').first
-    if token && token.user.groups.where(permit_token: true).any?
+    if token && token.user.asserted_groups.where(permit_token: true).any?
       @user = token.user
       token.update(last_used_at: Time.now.utc)
     end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -40,7 +40,7 @@ class DashboardController < ApplicationController
                    .where(show_on_dashboard: true)
                    .or(
                      SamlServiceProvider
-                     .where(group_service_providers: { group: current_user.groups })
+                     .where(group_service_providers: { group: current_user.asserted_groups })
                    )
   end
 
@@ -51,7 +51,7 @@ class DashboardController < ApplicationController
                      .where(show_on_dashboard: true)
                      .or(
                        Application
-                       .where(group_service_providers: { group: current_user.groups })
+                       .where(group_service_providers: { group: current_user.asserted_groups })
                      )
   end
 end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -11,7 +11,7 @@ class SamlIdpController < SamlIdp::IdpController
   def create
     if user_signed_in?
       app = SamlServiceProvider.find_by(issuer_or_entity_id: @saml_request.issuer)
-      if app&.groups&.any? && (current_user.groups & app.groups).empty?
+      if app&.groups&.any? && (current_user.asserted_groups & app.groups).empty?
         redirect_to main_app.root_url,
                     notice: 'You are not authorized to access this application.' and return
       end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -15,7 +15,7 @@ Doorkeeper.configure do # rubocop:disable Metrics/BlockLength
 
     if user_signed_in?
       if app&.groups&.any?
-        if (current_user.groups & app.groups).empty?
+        if (current_user.asserted_groups & app.groups).empty?
           redirect_to main_app.root_url, notice: 'You are not authorized to access this application.'
         else
           current_user


### PR DESCRIPTION
In both validating token permissions as well as validating SAML and
OIDC group membership, asserted_groups should be used to ensure that
any group membership requirements (eg: MFA) are upheld correctly.

Closes #390