### PR TITLE
Changes to sensitive data should be logged, but not visible.

### DIFF
--- a/app/controllers/admin/audits_controller.rb
+++ b/app/controllers/admin/audits_controller.rb
@@ -15,6 +15,21 @@ class Admin::AuditsController < AdminController
     %w[auditable_type action audited_changes]
   end
 
+  def hide_attribute?(attr_name)
+    filtered_attrs = %w[encrypted_password reset_password_token]
+    return false unless filtered_attrs.include? attr_name
+
+    true
+  end
+
+  def redact(data)
+    data.each do |key, _value|
+      data[key] = '<REDACTED>' if hide_attribute?(key)
+    end
+    data
+  end
+  helper_method :redact
+
   def ensure_user_is_authorized!
     raise(ActionController::RoutingError, 'Not Found') \
       unless current_user&.admin?

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -147,6 +147,18 @@ class Setting < ApplicationRecord
     end
   end
 
+  def maybe_hide_attribute(data)
+    return nil if data['value'].nil?
+    return if data['value'].last.nil?
+    value = if data['value'].is_a?(Array)
+      data['value']
+    else
+      [data['value']]
+    end
+    filtered_attrs = ['saml_key', 'oidc_signing_key']
+    return value.last unless filtered_attrs.include? var
+    return "Sha1 of secret: #{OpenSSL::Digest::SHA1.hexdigest value.last}"
+  end
   field :idp_base
   field :saml_certificate
   field :saml_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   extend Notifiable
   include Notifiable
 
-  audited only: %i[username name]
+  audited only: %i[username name encrypted_password reset_password_token]
 
   has_many :emails, dependent: :destroy
   has_many :access_tokens, dependent: :destroy

--- a/app/views/admin/audits/index.html.erb
+++ b/app/views/admin/audits/index.html.erb
@@ -34,6 +34,9 @@
   <tbody>
     <% @models.each do |model| %>
       <tr>
+      <% begin %>
+        <%= render partial: "#{model.auditable_type.underscore.gsub('/', '_')}_row", locals: {model: model} %>
+      <% rescue ActionView::MissingTemplate %>
         <td class="text-nowrap">
           <%= link_to fa_icon('eye', title: 'Show'), admin_audit_path(model.id) %>
         </td>
@@ -45,12 +48,13 @@
               <%- data =  data.join ", " %>
             <%- end %>
             <%- if attr_name == 'audited_changes' %>
-                <pre><code><%= data.to_yaml %></code></pre>
+                <pre><code><%= redact(data).to_yaml %></code></pre>
             <%- else %>
               <%= data %>
-              <%- end %>
+            <%- end %>
           </td>
         <%- end %>
+      <%- end %>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
When a user changes their password or has a password reset, these changes
should be audited; however, the hashed values should not be displayed in
the audit logs.

Additionally, when OIDC or SAML keys are updated, the secrets should not
be displayed in audit logs.