### PR TITLE
An operator should not be able to configure app templates

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -46,21 +46,22 @@ class Admin::SettingsController < AdminController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def setting_params # rubocop:disable Metrics/MethodLength
-    params.fetch(:setting, {}).permit(
-      :idp_base, :html_title_base,
-      :profiler_enabled,
-      :devise_reset_password_within,
-      :session_timeout_in,
-      :sudo_session_duration, :sudo_enabled, :sudo_for_sso,
-      :saml_certificate, :saml_key, :saml_timeout,
-      :oidc_signing_key,
-      :registration_enabled, :permanent_email,
-      :logo, :logo_height, :logo_width, :favicon,
-      :dashboard_template, :registered_home_template,
-      :expire_after, :welcome_from_email,
-      :admin_reset_email_template, :admin_welcome_email_template,
-      :admin_reset_email_template_plaintext, :admin_welcome_email_template_plaintext
-    )
+    permitted_settings = %i[
+      idp_base html_title_base
+      profiler_enabled
+      devise_reset_password_within
+      session_timeout_in
+      sudo_session_duration sudo_enabled sudo_for_sso
+      saml_certificate saml_key saml_timeout
+      oidc_signing_key
+      registration_enabled permanent_email
+      logo logo_height logo_width favicon
+      expire_after welcome_from_email
+      admin_reset_email_template admin_welcome_email_template
+      admin_reset_email_template_plaintext admin_welcome_email_template_plaintext
+    ]
+    permitted_settings += %i[dashboard_template registered_home_template] if current_user.admin?
+    params.fetch(:setting, {}).permit(permitted_settings)
   end
 
   def ensure_user_is_authorized!

--- a/app/views/admin/settings/templates.html.erb
+++ b/app/views/admin/settings/templates.html.erb
@@ -1,5 +1,6 @@
 <%= form_tag({controller: "settings", action: "update"}, method: :post, class: "form") do |form| %>
   <h1>Templates</h1>
+  <%- if current_user.admin? %>
   <div class="form-group">
     <label for="settings[dashboard_template]">Dashboard template</label>
     <textarea name="setting[dashboard_template]" class="form-control" ><%= Setting.dashboard_template %></textarea>
@@ -8,6 +9,7 @@
     <label for="settings[registered_home_template]">Profile header template</label>
     <textarea name="setting[registered_home_template]" class="form-control" ><%= Setting.registered_home_template %></textarea>
   </div>
+  <%- end %>
   <div class="form-group">
     <label for="settings[admin_reset_email_template]">Password reset email template</label>
     <textarea name="setting[admin_reset_email_template]" class="form-control" ><%= Setting.admin_reset_email_template %></textarea>

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -78,6 +78,28 @@ RSpec.describe Admin::SettingsController, type: :controller do
           expect(response.body).not_to include 'Confirm password to continue'
         end
       end
+
+      it 'cannot change dashboard_template' do
+        Setting.dashboard_template = 'Default EyeDP Template'
+        post(:update, params: { setting: { dashboard_template: 'Custom dashboard Template' } })
+        expect(Setting.dashboard_template).to eq 'Default EyeDP Template'
+      end
+
+      it 'cannot change the registered_home_template' do
+        Setting.registered_home_template = 'Default EyeDP Template'
+        post(:update, params: { setting: { registered_home_template: 'Custom home Template' } })
+        expect(Setting.registered_home_template).to eq 'Default EyeDP Template'
+      end
+
+      context 'with rendered views' do
+        render_views
+        it 'Does not show forbidden templates' do
+          Setting.saml_certificate = File.read(Rails.root.join('spec/myCert.crt'))
+          get :templates
+          expect(response.body).not_to include('registered_home_template')
+          expect(response.body).not_to include('dashboard_template')
+        end
+      end
     end
 
     context 'signed in admin' do
@@ -257,6 +279,18 @@ RSpec.describe Admin::SettingsController, type: :controller do
           expect(Setting.oidc_signing_key).to be nil
           post(:update, params: { setting: { oidc_signing_key: 'this is a test' } })
           expect(Setting.oidc_signing_key).to eq 'this is a test'
+        end
+
+        it 'can change dashboard_template' do
+          Setting.dashboard_template = 'Default EyeDP Template'
+          post(:update, params: { setting: { dashboard_template: 'Custom dashboard Template' } })
+          expect(Setting.dashboard_template).to eq 'Custom dashboard Template'
+        end
+
+        it 'can change the registered_home_template' do
+          Setting.registered_home_template = 'Default EyeDP Template'
+          post(:update, params: { setting: { registered_home_template: 'Custom home Template' } })
+          expect(Setting.registered_home_template).to eq 'Custom home Template'
         end
       end
     end


### PR DESCRIPTION
When an operator has the ability to set templates, they can potentially abuse
the templating to escalate their privileges to an admin user