### PR TITLE
Add more logging to User creation errors, and do not use remote forms…

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Run security checks
         run: |
           bin/brakeman -q -w2
-          gem install bundle-audit
-          bundle-audit update
-          bundle-audit
 
   tests:
     name: Tests

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -22,9 +22,12 @@ class Admin::UsersController < AdminController # rubocop:disable Metrics/ClassLe
     respond_to do |format|
       if @model.save
         format.html { redirect_to [:admin, @model], notice: "#{@model.class.name} was successfully created." }
+        format.js { redirect_to [:admin, @model], notice: "#{@model.class.name} was successfully created." }
         format.json { render :show, status: :created, location: [:admin, @model] }
       else
+        Rails.logger.warn("Error creating user: #{@model.errors}")
         format.html { render :new }
+        format.js { render :new }
         format.json { render json: @model.errors, status: :unprocessable_entity }
       end
     end

--- a/app/views/admin/new.js.erb
+++ b/app/views/admin/new.js.erb
@@ -1,1 +1,1 @@
-<%= render 'form', model: @model, new_model: true, remote: true %>
+<%= render 'form', model: @model, new_model: true, remote: false %>


### PR DESCRIPTION
… (#408)

Remote forms make it quite difficult to diagnose
failures as the user creating a model doesn't get
informed about errors. By removing the remote form,
an admin will see the page with form errors presented