### PR TITLE
full-width login on small screens

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-  <div class="col-4">
+  <div class="col-12 col-md-4">
     <h2><%= t('.resend_confirmation_instructions') %></h2>
 
     <%= form_for(resource, as: resource_name, url: user_confirmation_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-  <div class="col-4">
+  <div class="col-12 col-md-4">
     <h2><%= t('.forgot_your_password') %></h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-  <div class="col-4">
+  <div class="col-12 col-md-4">
     <h2><%= t('.sign_up') %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-  <div class="col-4">
+  <div class="col-12 col-md-4">
     <h2><%= t('.sign_in') %></h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/devise/sessions/two_factor.html.erb
+++ b/app/views/devise/sessions/two_factor.html.erb
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-  <div class="col-4">
+  <div class="col-12 col-md-4">
     <h2><%= t('.log_in') %></h2>
 
     <%- resource_params = params[resource_name].presence || params %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-  <div class="col-4">
+  <div class="col-12 col-md-4">
     <h2><%= t('.resend_unlock_instructions') %></h2>
 
     <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>


### PR DESCRIPTION
Optimize pre-auth login and account management pages for mobile login with on-screen keyboard. Brings the primary action button in view with and without OSK.

| Before | After |
| --- | --- |
| <img width="488" alt="eyedp_login_before" src="https://user-images.githubusercontent.com/473924/202424621-90b43951-bd97-49b9-a2ce-fab5c63289ce.png"> | <img width="488" alt="eyedp_login_after" src="https://user-images.githubusercontent.com/473924/202424602-7d249491-5b03-4a44-bc36-407f445c059f.png"> |
| <img width="488" alt="eyedp_2fa_before" src="https://user-images.githubusercontent.com/473924/202425244-ebd7ac84-a875-488d-ab91-0acf6790e98c.png"> | <img width="488" alt="eyedp_2fa_after" src="https://user-images.githubusercontent.com/473924/202425312-fc07ade8-552d-4c6a-bf99-7cca766222a7.png"> |
