### PR TITLE
Do not empty email addresses

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -56,6 +56,8 @@ class Admin::UsersController < AdminController # rubocop:disable Metrics/ClassLe
     address = model_params.delete(:email)
     all_addresses = addresses << address
     all_addresses.compact!
+    return unless all_addresses.any?
+
     @model.emails.where.not(address: all_addresses).destroy_all
     all_addresses.each do |email_address|
       Email.find_or_create_by(user: @model, address: email_address, confirmed_at: Time.zone.now)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -81,6 +81,22 @@
       "note": "This is restricted to be only a same-host redirect or to a non fully-qualified path"
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 121,
+      "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.1 ended on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 295,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "High",
+      "note": ""
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "a3a01e05b8cd146c65165655f46883113d7dbb4dca33096f53796438aa46d889",
@@ -174,6 +190,6 @@
       "note": "Setting.dashboard_template is only configurable by an admin."
     }
   ],
-  "updated": "2021-12-11 17:21:29 +0100",
-  "brakeman_version": "5.1.1"
+  "updated": "2023-04-26 14:52:25 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -495,6 +495,16 @@ RSpec.describe Admin::UsersController, type: :controller do
             expect(response.body).to include(%(type="checkbox" value="#{manager_group.id}" name="user[group_ids][]"))
           end
 
+          it 'disables a user without removing data' do
+            expect(user.emails.first.address).to eq('user@localhost')
+            expect(user.emails.first.confirmed?).to be_truthy
+            post(:update, params: { id: user.id, user: { disabled_at: Time.now.utc } })
+            user.reload
+            expect(user.emails.first.address).to eq('user@localhost')
+            expect(user.emails.first.confirmed?).to be_truthy
+            expect(user.disabled?).to be_truthy
+          end
+
           it "shows a user's custom attributes" do
             t = CustomUserdataType.create(name: 'Has pets', custom_type: 'boolean')
             admin.custom_userdata << CustomUserdatum.create(custom_userdata_type: t, value: true)


### PR DESCRIPTION
When some user updates occur, a full user object
is not passed in. In this case, ensure that we
do not delete emails with an empty list

Closes #463